### PR TITLE
Dashboard touchup: Quality page, Tonight projection, current-month he…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Static, client-side web app for logging and visualizing sleep (bed time, sleep start/end, naps, interruptions). No backend or build step; it runs in the browser with HTML, CSS, and vanilla JavaScript.
 
+**Run:** Open `index.html` or `dashboard.html` in a browser (or use a local static server if you hit CORS with `fetch()`).
+
 ---
 
 ## Architecture & Stack
@@ -13,14 +15,14 @@ Static, client-side web app for logging and visualizing sleep (bed time, sleep s
 | **Charts** | SVG drawn in JS (no chart library) |
 | **Styling** | Single `sleep.css` with CSS variables (dark theme) |
 
-- **Data source:** `sleep-data.json` (array of daily records) and `holidays.json` (year → month → list of holiday days).
-- **Shared logic:** `sleep-utils.js` holds time math, date helpers, and `renderNavBar()`. `sleep.js` holds dashboard/timeline logic and is the main "core" script. Page-specific scripts: `dashboard.js`, `graph.js`, `stats.js`.
+- **Data source:** `sleep-data.json` (object with a `days` array of daily records) and `holidays.json` (year → month → list of holiday days).
+- **Shared logic:** `sleep-utils.js` holds time math, date helpers, and `renderNavBar()`. `sleep.js` holds dashboard/timeline/heatmap logic and is the main "core" script. Page-specific scripts: `dashboard.js`, `quality.js`, `graph.js`, `stats.js`.
 
 ---
 
 ## Data Model
 
-Each day in `sleep-data.json` has:
+Each day in the `days` array of `sleep-data.json` has:
 
 - **`date`** – `"M/D"` (e.g. `"3/9"`).
 - **`bed`**, **`sleepStart`**, **`sleepEnd`** – `"HH:MM"` (24h).
@@ -35,21 +37,26 @@ Time is normalized as **minutes from midnight** (0–1440) everywhere, with expl
 
 ### 1. Dashboard (`dashboard.html` + `dashboard.js` + `sleep.js`)
 - Loads `sleep-data.json` and `holidays.json`.
-- Renders recent/lifetime averages, last few nights as timeline rows, sleep-quality history, and a **calendar heatmap** of "flag" days (deviations).
-- Uses `renderDashboardContent()`, `renderWeek()`, `renderDay()`, `renderCalendarHeatmap()` from `sleep.js`.
+- Renders recent/lifetime averages, last few nights as timeline rows, and the **current month** of the sleep-quality calendar heatmap.
+- Uses `renderDashboardContent()`, `renderCalendarHeatmapCurrentMonthOnly()` from `sleep.js`.
 
-### 2. Daily Timeline (`sleep.html` + `sleep.js`)
+### 2. Sleep Quality (`quality.html` + `quality.js` + `sleep.js`)
+- Loads `sleep-data.json` and `holidays.json`.
+- Renders the **full** sleep quality history: all months in a calendar heatmap of "flag" days (deviations vs 7-day avg).
+- Uses `renderCalendarHeatmapFullHistory()`, `buildFlagCountMap()`, `getLatestDataDate()` from `sleep.js`.
+
+### 3. Daily Timeline (`sleep.html` + `sleep.js`)
 - Timeline from **22:00 previous day** to **24:00 current day** (config in `sleep.js`: `TIMELINE_START_MINUTES`, `TIME_TICKS`).
 - Renders **weeks** (expandable), each day as a horizontal bar: bed, sleep, nap, bathroom, alarm, sick, get-up.
 - Week grouping is **Monday–Sunday** (ISO-style); current/previous week start expanded.
 
-### 3. Graphs (`graph.html` + `graph.js`)
+### 4. Graphs (`graph.html` + `graph.js`)
 - Loads same JSON; no `sleep.js`, only `sleep-utils.js`.
 - **Line chart:** bed time, fell-asleep time, get-up time over days (Y = time 17:00→17:00 next day); **quadratic regression** (polynomial regression + Gaussian elimination in `graph.js`) for trend lines; toggles to show/hide series.
 - **Bar charts:** sleep duration and "delay" (e.g. bed-to-sleep) per day.
 - All charts are **SVG** drawn in code.
 
-### 4. Stats (`stats.html` + `stats.js`)
+### 5. Stats (`stats.html` + `stats.js`)
 - **Monthly** stats: total sleep, averages, longest uninterrupted stretch, alarm-to-wake, bed-to-sleep delay, nap stats.
 - Uses `groupDaysByMonth()`, `calculateLongestUninterrupted()`, `calculateFirstAlarmToWake()`, `calculateBedToSleepDelay()`, `calculateNapDuration()` in `stats.js`.
 - Renders comparison vs other months (e.g. "higher/lower than average").
@@ -73,7 +80,7 @@ Time is normalized as **minutes from midnight** (0–1440) everywhere, with expl
 - Used for styling (e.g. weekend background) and possibly filtering in the UI.
 
 ### UI
-- Shared **nav bar** via `renderNavBar(currentPage)` (Dashboard, Daily Timeline, Graphs, Stats).
+- Shared **nav bar** via `renderNavBar(currentPage)` (Dashboard, Quality, Daily, Graphs, Stats).
 - Dark theme in `sleep.css` (e.g. `--bg`, `--panel`, `--color-sleep`, `--color-alarm`).
 - Tooltips and day panels for graph hover.
 
@@ -83,11 +90,13 @@ Time is normalized as **minutes from midnight** (0–1440) everywhere, with expl
 
 | File | Role |
 |------|------|
-| `sleep-data.json` | Source of truth for daily sleep records |
+| `index.html` | Redirects to `dashboard.html` (entry point) |
+| `sleep-data.json` | Source of truth; object with `days` array of daily records |
 | `holidays.json` | Holiday calendar by year/month/day |
 | `sleep-utils.js` | Time/date helpers, `calculateTotalSleep()`, `renderNavBar()` |
 | `sleep.js` | Timeline rendering, week grouping, dashboard content, deviation logic, heatmap |
 | `dashboard.js` | Fetches data and calls `renderDashboardContent()` |
+| `quality.js` | Fetches data and calls `renderCalendarHeatmapFullHistory()` for full history |
 | `graph.js` | Fetches data, regression, SVG line/bar charts |
 | `stats.js` | Monthly aggregation and stat rendering |
 | `sleep.css` | Global styles and CSS variables |

--- a/graph.html
+++ b/graph.html
@@ -80,7 +80,7 @@
         // isWeekend, and isHoliday are now in sleep-utils.js
         // Use getDateFromString(dateString, year) instead of parseDate
 
-        // Calculate wake delay (first alarm to wake up)
+        // Calculate wake delay (alarm to wake up)
         function calculateWakeDelay(day) {
           if (!day.alarm || day.alarm.length === 0) {
             return null;

--- a/quality.html
+++ b/quality.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sleep Quality History</title>
+<link rel="stylesheet" href="sleep.css">
+</head>
+<body>
+  <div id="nav-container"></div>
+  <div class="container">
+    <div id="quality-container"></div>
+  </div>
+
+  <script src="sleep-utils.js"></script>
+  <script src="sleep.js"></script>
+  <script src="quality.js"></script>
+  <script>
+    document.getElementById('nav-container').innerHTML = renderNavBar('quality');
+  </script>
+</body>
+</html>

--- a/quality.js
+++ b/quality.js
@@ -1,0 +1,20 @@
+// Sleep Quality History: full calendar heatmap (all months).
+// Uses renderCalendarHeatmapFullHistory() and shared helpers from sleep.js.
+
+const qualityContainer = document.getElementById('quality-container');
+if (qualityContainer) {
+  Promise.all([
+    fetch('sleep-data.json').then(r => r.json()),
+    fetch('holidays.json').then(r => r.json())
+  ])
+    .then(([sleepData, holidaysData]) => {
+      if (typeof holidays !== 'undefined') holidays = holidaysData;
+      const flagMap = buildFlagCountMap(sleepData.days);
+      const latestDataDate = getLatestDataDate(sleepData.days, YEAR);
+      qualityContainer.innerHTML = renderCalendarHeatmapFullHistory(YEAR, flagMap, latestDataDate);
+    })
+    .catch(error => {
+      console.error('Error loading quality history data:', error);
+      qualityContainer.innerHTML = '<p>Error loading data.</p>';
+    });
+}

--- a/sleep-data.json
+++ b/sleep-data.json
@@ -1,6 +1,16 @@
 {
   "days": [
     {
+      "date": "3/10",
+      "bed": "21:33",
+      "sleepStart": "22:00",
+      "sleepEnd": "7:07",
+      "bathroom": ["3:05"],
+      "alarm": ["6:50"],
+      "sick": [],
+      "nap": null
+    },
+    {
       "date": "3/9",
       "bed": "21:52",
       "sleepStart": "22:10",

--- a/sleep-utils.js
+++ b/sleep-utils.js
@@ -125,7 +125,8 @@ const GITHUB_REPO_URL = 'https://github.com/rsairu/sleep/';
 function renderNavBar(currentPage) {
   const pages = [
     { id: 'dashboard', name: 'Dashboard', url: 'dashboard.html', icon: '🛌' },
-    { id: 'timeline', name: 'Daily Timeline', url: 'sleep.html', icon: '📅' },
+    { id: 'quality', name: 'Quality', url: 'quality.html', icon: '🟩' },
+    { id: 'timeline', name: 'Daily', url: 'sleep.html', icon: '📅' },
     { id: 'graph', name: 'Graphs', url: 'graph.html', icon: '📊' },
     { id: 'stats', name: 'Stats', url: 'stats.html', icon: '🔢' }
   ];

--- a/sleep.css
+++ b/sleep.css
@@ -1,6 +1,6 @@
 :root{
-  --minutes: 1560; /* 26 hours: 22:00 previous day to 24:00 current day */
-  --previous-day-minutes: 120; /* 2 hours: 22:00-00:00 */
+  --minutes: 1440; /* 24 hours: 20:00 to 20:00 next day */
+  --previous-day-minutes: 240; /* 4 hours: 20:00-00:00 */
   --bar-h: 18px;
   --tick-h: 30px;
   --tick-w: 3px;
@@ -19,6 +19,7 @@
   --color-sick: #ec4899;
   --color-bath: #fbbf24;
   --color-up: #34d399;
+  --color-sunrise: #f59e0b;
   --color-warning: #f87171;
   --color-default-event: #e5e7eb;
   --color-hover-blue: #93c5fd;
@@ -220,6 +221,142 @@ body{
   gap: 20px;
 }
 
+.dashboard-projection {
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 18px 20px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dashboard-projection--no-box {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+}
+
+.dashboard-top-row {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.dashboard-top-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.dashboard-top-col--tonight {
+  flex: 0 1 auto;
+}
+
+.dashboard-top-col--calendar {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.dashboard-top-col--calendar .calendar-heatmap--inline {
+  margin: 0;
+  width: 100%;
+}
+
+.dashboard-top-col--calendar .calendar-current-month-row {
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-weekday-cells--in-block {
+  display: flex;
+  width: 100%;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-weekday-label {
+  flex: 1;
+  min-width: 0;
+  width: auto;
+  max-width: none;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-month-row {
+  width: 100%;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-days-row {
+  display: flex;
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-square {
+  flex: 1;
+  min-width: 0;
+  width: auto;
+  max-width: none;
+}
+
+.calendar-heatmap--inline {
+  margin: 0;
+}
+
+.dashboard-projection-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  color: var(--text);
+  opacity: 0.95;
+}
+
+.dashboard-projection-copy {
+  font-size: 0.8rem;
+  margin: 0 0 14px 0;
+  opacity: 0.75;
+}
+
+.dashboard-projection-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dashboard-projection-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dashboard-projection-item--wake {
+  margin-top: 2px;
+}
+
+.dashboard-projection-label {
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.proj-keyword.proj-sleep {
+  color: var(--color-sleep);
+  font-weight: 600;
+}
+
+.proj-keyword.proj-wake {
+  color: var(--color-sunrise);
+  font-weight: 600;
+}
+
+.dashboard-projection-range {
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+
 .dashboard-averages-panel{
   background: var(--panel);
   border-radius: 14px;
@@ -230,6 +367,12 @@ body{
   background: var(--panel);
   border-radius: 14px;
   padding: 14px 16px 18px;
+}
+
+/* On dashboard only: no blue band behind Sat/Sun */
+.dashboard-past-nights .day.weekend{
+  background: var(--panel);
+  border-top: none;
 }
 
 .dashboard-section-title{
@@ -404,6 +547,7 @@ body{
   background: var(--warning-bg);
   border-radius: 6px;
   border-left: 2px solid var(--warning-border);
+  width: fit-content;
 }
 
 .day-bar-container{
@@ -1242,6 +1386,12 @@ svg {
   gap: 8px;
 }
 
+/* Dashboard: legend under the title */
+.calendar-heatmap-container--dashboard .calendar-heatmap-header {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 .calendar-heatmap-title {
   font-size: 14px;
   font-weight: 600;
@@ -1363,6 +1513,58 @@ svg {
   overflow-x: auto;
   overflow-y: visible;
   padding: 4px 0;
+}
+
+/* Dashboard: current month in its own row at top, twice as big */
+.calendar-current-month-row {
+  margin-bottom: 20px;
+  width: fit-content;
+}
+
+.calendar-month-block--large {
+  padding: 16px 20px;
+}
+
+.calendar-month-block--large .calendar-month-header {
+  margin-bottom: 8px;
+}
+
+.calendar-month-block--large .calendar-month-name {
+  font-size: 22px;
+}
+
+.calendar-month-block--large .calendar-month-flag-counter {
+  font-size: 22px;
+  gap: 12px;
+}
+
+.calendar-month-block--large .calendar-month-flag-counter .calendar-flag-slot {
+  font-size: 22px;
+}
+
+.calendar-month-block--large .calendar-weekday-cells--in-block {
+  margin-bottom: 4px;
+  gap: 6px;
+}
+
+.calendar-month-block--large .calendar-weekday-label {
+  width: 24px;
+  height: 24px;
+  font-size: 16px;
+}
+
+.calendar-month-block--large .calendar-days-row {
+  gap: 6px;
+}
+
+.calendar-month-block--large .calendar-square {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+}
+
+.calendar-month-block--large .calendar-square-day {
+  font-size: 14px;
 }
 
 .calendar-month-grid {

--- a/sleep.js
+++ b/sleep.js
@@ -9,12 +9,12 @@ const DATA_FILES = {
 
 // Time constants
 const MILLISECONDS_PER_DAY = 86400000;
-// Timeline starts at 22:00 previous day, so ticks are: 22 (previous day), 0, 4, 8, 12, 16, 20, 24 (current day)
-// In timeline minutes: 0, 120, 360, 600, 840, 1080, 1320, 1440
-const TIME_TICKS = [0, 120, 360, 600, 840, 1080, 1320, 1440]; // 22, 0, 4, 8, 12, 16, 20, 24 hours
-const TIMELINE_START_HOUR = 22; // Timeline starts at 22:00 previous day (1320 minutes from midnight)
-const TIMELINE_START_MINUTES = 1320; // 22:00 in minutes
-const PREVIOUS_DAY_DURATION = 120; // 2 hours from 22:00 to 00:00
+// Timeline runs 20:00 to 20:00 (24 hours). Ticks: 20 (start), 0, 4, 8, 12, 16, 20 (end)
+// In timeline minutes: 0, 240, 600, 840, 1080, 1320, 1440
+const TIME_TICKS = [0, 240, 600, 840, 1080, 1320, 1440]; // 20, 0, 4, 8, 12, 16, 20 hours
+const TIMELINE_START_HOUR = 20; // Timeline starts at 20:00 (1200 minutes from midnight)
+const TIMELINE_START_MINUTES = 1200; // 20:00 in minutes
+const PREVIOUS_DAY_DURATION = 240; // 4 hours from 20:00 to 00:00
 
 // Holidays data (loaded from holidays.json)
 let holidays = {};
@@ -100,17 +100,20 @@ function formatWeekRange(monday) {
 // Note: timeToMinutes is now in sleep-utils.js
 
 // Convert time (minutes from midnight) to timeline position
-// Timeline starts at 22:00 previous day (1320 minutes from midnight)
-// Times >= 1320 are on previous day portion (0-120 on timeline)
-// Times < 1320 are on current day portion (120-1440 on timeline)
+// Timeline runs 20:00 to 20:00 (24h). Times >= 20:00 (1200) → 0–239; times < 20:00 → 240–1439
 function timeToTimelinePosition(minutesFromMidnight) {
   if (minutesFromMidnight >= TIMELINE_START_MINUTES) {
-    // Time is on previous day (22:00-23:59)
+    // 20:00–23:59
     return minutesFromMidnight - TIMELINE_START_MINUTES;
   } else {
-    // Time is on current day (00:00-21:59)
+    // 00:00–19:59 (next day on timeline)
     return minutesFromMidnight + PREVIOUS_DAY_DURATION;
   }
+}
+
+// Bed time uses same timeline position as everything else (timeline now starts at 20:00)
+function bedMinutesForTimeline(bedMinutes) {
+  return timeToTimelinePosition(bedMinutes);
 }
 
 // Note: formatDuration and formatTime are now in sleep-utils.js
@@ -492,6 +495,8 @@ function renderDay(day, days, dayIndex, options) {
   if (isHolidayDay) dayClasses.push('holiday');
   if (isWeekendDay) dayClasses.push('weekend');
   
+  const dayOfWeek = getDateFromString(day.date, YEAR).toLocaleDateString('en-US', { weekday: 'short' });
+  
   // Check for deviations from recent averages
   const recentAverages = calculateRecentAverages(days, dayIndex);
   const deviations = checkDeviations(day, recentAverages);
@@ -502,16 +507,17 @@ function renderDay(day, days, dayIndex, options) {
   // Convert times to timeline positions
   const sleepStartPos = timeToTimelinePosition(sleepStart);
   const sleepEndPos = timeToTimelinePosition(sleepEnd);
-  const bedPos = timeToTimelinePosition(timeToMinutes(day.bed));
+  const bedMinutes = timeToMinutes(day.bed);
+  const bedPos = bedMinutesForTimeline(bedMinutes);
   
-  // Time tick labels: 22 (previous day), 0, 4, 8, 12, 16, 20, 24 (current day)
-  const tickLabels = [22, 0, 4, 8, 12, 16, 20, 24];
+  // Time tick labels: 20 (start), 0, 4, 8, 12, 16, 20 (end)
+  const tickLabels = [20, 0, 4, 8, 12, 16, 20];
   const barClass = 'bar' + (showTicks ? ' show-ticks' : '');
   
   let html = `
     <div class="day ${dayClasses.join(' ')}">
       <div class="day-content">
-        <div class="day-date">${day.date}${isHolidayDay ? ' 🎉' : ''}</div>
+        <div class="day-date">${day.date} ${dayOfWeek}${isHolidayDay ? ' 🎉' : ''}</div>
         <div class="day-bar-container">
           <div class="${barClass}">
             <!-- Faded overlay for previous day section (22:00-00:00) -->
@@ -552,7 +558,7 @@ function renderDay(day, days, dayIndex, options) {
           <div class="stat-row"><span class="stat-label">${highlightKeyword('fell asleep:', 'asleep')}</span><span class="stat-value">${day.sleepStart}</span></div>
           <div class="stat-row"><span class="stat-label">${highlightKeyword('sleep duration:', 'sleep')}</span><span class="stat-value">${formatDuration(sleepDuration)}</span></div>
           <div class="stat-row"><span class="stat-label">longest uninterrupted:</span><span class="stat-value">${formatDuration(longestUninterrupted)}</span></div>
-          ${firstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('first alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${firstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(firstAlarmToWake)}</span></div>` : ''}
+          ${firstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${firstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(firstAlarmToWake)}</span></div>` : ''}
         </div>
       </div>
       ${deviationWarnings}
@@ -599,7 +605,7 @@ function renderAveragesStats(averages) {
         <div class="stat-row"><span class="stat-label">${highlightKeyword('fell asleep:', 'asleep')}</span><span class="stat-value">${formatTime(averages.avgBedtime)}</span></div>
     <div class="stat-row"><span class="stat-label">${highlightKeyword('sleep duration:', 'sleep')}</span><span class="stat-value">${formatDuration(averages.avgSleepDuration)}</span></div>
     <div class="stat-row"><span class="stat-label">longest uninterrupted:</span><span class="stat-value">${formatDuration(averages.avgLongestUninterrupted)}</span></div>
-    ${averages.avgFirstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('first alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${averages.avgFirstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(averages.avgFirstAlarmToWake)}</span></div>` : ''}
+    ${averages.avgFirstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${averages.avgFirstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(averages.avgFirstAlarmToWake)}</span></div>` : ''}
   `;
 }
 
@@ -615,7 +621,7 @@ function renderAveragesColumn(averages, title) {
   `;
 }
 
-// Render last night column (single day: fell asleep, duration, longest uninterrupted, first alarm to wake)
+// Render last night column (single day: fell asleep, duration, longest uninterrupted, alarm to wake)
 function renderLastNightColumn(day) {
   const sleepDuration = calculateTotalSleep(day);
   const longestUninterrupted = calculateLongestUninterrupted(day);
@@ -627,7 +633,7 @@ function renderLastNightColumn(day) {
         <div class="stat-row"><span class="stat-label">${highlightKeyword('fell asleep:', 'asleep')}</span><span class="stat-value">${day.sleepStart}</span></div>
         <div class="stat-row"><span class="stat-label">${highlightKeyword('sleep duration:', 'sleep')}</span><span class="stat-value">${formatDuration(sleepDuration)}</span></div>
         <div class="stat-row"><span class="stat-label">longest uninterrupted:</span><span class="stat-value">${formatDuration(longestUninterrupted)}</span></div>
-        ${firstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('first alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${firstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(firstAlarmToWake)}</span></div>` : ''}
+        ${firstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${firstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(firstAlarmToWake)}</span></div>` : ''}
       </div>
     </div>
   `;
@@ -640,7 +646,7 @@ function renderWeekSummary(days) {
   const avgSleepEnd = averages.avgSleepEnd;
   const avgSleepStartPos = timeToTimelinePosition(avgSleepStart);
   const avgSleepEndPos = timeToTimelinePosition(avgSleepEnd);
-  const tickLabels = [22, 0, 4, 8, 12, 16, 20, 24];
+  const tickLabels = [20, 0, 4, 8, 12, 16, 20];
   
   return `
     <div class="week-summary">
@@ -815,78 +821,148 @@ function getFlagColorClass(flagCount) {
   return 'flag-three-plus';
 }
 
-// Render calendar heatmap
-function renderCalendarHeatmap(year, flagMap, latestDataDate) {
-  const months = generateCalendarHeatmap(year, flagMap, latestDataDate);
-  
-  let html = `
-    <div class="calendar-heatmap-container">
-      <div class="calendar-heatmap-header">
-        <h3 class="calendar-heatmap-title">Sleep Quality history</h3>
-        <div class="calendar-heatmap-legend calendar-heatmap-legend--compact">
-          <div class="legend-colors-row">
-            <span class="legend-label">normal</span>
-            <div class="legend-colors">
-              <div class="legend-square flag-none"></div>
-              <div class="legend-square flag-one"></div>
-              <div class="legend-square flag-two"></div>
-              <div class="legend-square flag-three-plus"></div>
-            </div>
-            <span class="legend-label">worse</span>
-          </div>
-          <span class="legend-divider">·</span>
-          <div class="legend-meaning legend-meaning--inline">
-            <span class="legend-meaning-item">🛌 bed late</span>
-            <span class="legend-meaning-item">😴 asleep late</span>
-            <span class="legend-meaning-item">⌛ short</span>
-          </div>
-          <span class="legend-explanation legend-explanation--inline">(vs 7-day avg, 20+ min)</span>
-        </div>
+// Render a single month block (for heatmap). large: true adds --large class for 2x size on dashboard.
+function renderMonthBlock(month, large) {
+  const flagSlots = [
+    { emoji: '🛌', count: month.flagCounts['🛌'] },
+    { emoji: '😴', count: month.flagCounts['😴'] },
+    { emoji: '⌛', count: month.flagCounts['⌛'] }
+  ];
+  const flagHtml = flagSlots.map(f => `<span class="calendar-flag-slot"><span class="calendar-flag-emoji">${f.emoji}</span><span class="calendar-flag-num">${f.count}</span></span>`).join('');
+  const weekdayLabels = ['Su', 'M', 'T', 'W', 'R', 'F', 'Sa'].map(w => `<div class="calendar-weekday-label">${w}</div>`).join('');
+  const blockClass = 'calendar-month-block' + (large ? ' calendar-month-block--large' : '');
+  return `
+    <div class="${blockClass}">
+      <div class="calendar-month-header">
+        <div class="calendar-month-name">${month.name}</div>
+        <div class="calendar-month-flag-counter">${flagHtml}</div>
       </div>
+      <div class="calendar-weekday-cells calendar-weekday-cells--in-block">${weekdayLabels}</div>
+      ${month.weeks.map(weekRow => `
+        <div class="calendar-month-row">
+          <div class="calendar-days-row">
+            ${weekRow.map((day) => {
+              if (day === null) {
+                return `<div class="calendar-square empty"></div>`;
+              }
+              const colorClass = getFlagColorClass(day.flagCount);
+              const tooltip = day.flagCount > 0
+                ? `${day.dateStr}: ${day.flagTypes.join(' ')}`
+                : `${day.dateStr}: normal`;
+              return `<div class="calendar-square ${colorClass}" data-tooltip="${tooltip}" title="${tooltip}"><span class="calendar-square-day">${day.day}</span></div>`;
+            }).join('')}
+          </div>
+        </div>
+      `).join('')}
+    </div>
+  `;
+}
+
+// Shared header and legend for sleep quality calendar (used by dashboard and quality page)
+function renderCalendarHeatmapHeader() {
+  return `
+    <div class="calendar-heatmap-header">
+      <h3 class="calendar-heatmap-title">Sleep Quality history</h3>
+      <div class="calendar-heatmap-legend calendar-heatmap-legend--compact">
+        <div class="legend-colors-row">
+          <span class="legend-label">normal</span>
+          <div class="legend-colors">
+            <div class="legend-square flag-none"></div>
+            <div class="legend-square flag-one"></div>
+            <div class="legend-square flag-two"></div>
+            <div class="legend-square flag-three-plus"></div>
+          </div>
+          <span class="legend-label">worse</span>
+        </div>
+        <span class="legend-divider">·</span>
+        <div class="legend-meaning legend-meaning--inline">
+          <span class="legend-meaning-item">🛌 bed late</span>
+          <span class="legend-meaning-item">😴 asleep late</span>
+          <span class="legend-meaning-item">⌛ short</span>
+        </div>
+        <span class="legend-explanation legend-explanation--inline">(vs 7-day avg, 20+ min)</span>
+      </div>
+    </div>
+  `;
+}
+
+// Dashboard: current month only (full container with header and legend)
+function renderCalendarHeatmapCurrentMonthOnly(year, flagMap, latestDataDate) {
+  const months = generateCalendarHeatmap(year, flagMap, latestDataDate);
+  const now = new Date();
+  const isCurrentYear = year === now.getFullYear();
+  const currentMonthIndex = isCurrentYear ? now.getMonth() : null;
+  const currentMonthBlock = currentMonthIndex !== null ? renderMonthBlock(months[currentMonthIndex], true) : '';
+
+  return `
+    <div class="calendar-heatmap-container calendar-heatmap-container--dashboard">
+      ${renderCalendarHeatmapHeader()}
+      <div class="calendar-heatmap">
+        ${currentMonthBlock ? `<div class="calendar-current-month-row">${currentMonthBlock}</div>` : ''}
+      </div>
+    </div>
+  `;
+}
+
+// Dashboard inline: current month calendar only (no header, no legend)
+function renderCalendarCurrentMonthOnlyBlock(year, flagMap, latestDataDate) {
+  const months = generateCalendarHeatmap(year, flagMap, latestDataDate);
+  const now = new Date();
+  const isCurrentYear = year === now.getFullYear();
+  const currentMonthIndex = isCurrentYear ? now.getMonth() : null;
+  const currentMonthBlock = currentMonthIndex !== null ? renderMonthBlock(months[currentMonthIndex], true) : '';
+  if (!currentMonthBlock) return '';
+  return `
+    <div class="calendar-heatmap calendar-heatmap--inline">
+      <div class="calendar-current-month-row">${currentMonthBlock}</div>
+    </div>
+  `;
+}
+
+// Quality history page: all months in grid (no separate current-month row)
+function renderCalendarHeatmapFullHistory(year, flagMap, latestDataDate) {
+  const months = generateCalendarHeatmap(year, flagMap, latestDataDate);
+
+  return `
+    <div class="calendar-heatmap-container">
+      ${renderCalendarHeatmapHeader()}
       <div class="calendar-heatmap">
         <div class="calendar-month-grid">
-          ${months.map((month) => {
-            const flagSlots = [
-              { emoji: '🛌', count: month.flagCounts['🛌'] },
-              { emoji: '😴', count: month.flagCounts['😴'] },
-              { emoji: '⌛', count: month.flagCounts['⌛'] }
-            ];
-            const flagHtml = flagSlots.map(f => `<span class="calendar-flag-slot"><span class="calendar-flag-emoji">${f.emoji}</span><span class="calendar-flag-num">${f.count}</span></span>`).join('');
-            const weekdayLabels = ['Su', 'M', 'T', 'W', 'R', 'F', 'Sa'].map(w => `<div class="calendar-weekday-label">${w}</div>`).join('');
-            return `
-            <div class="calendar-month-block">
-              <div class="calendar-month-header">
-                <div class="calendar-month-name">${month.name}</div>
-                <div class="calendar-month-flag-counter">${flagHtml}</div>
-              </div>
-              <div class="calendar-weekday-cells calendar-weekday-cells--in-block">${weekdayLabels}</div>
-              ${month.weeks.map(weekRow => `
-                <div class="calendar-month-row">
-                  <div class="calendar-days-row">
-                    ${weekRow.map((day) => {
-                      if (day === null) {
-                        return `<div class="calendar-square empty"></div>`;
-                      }
-                      const colorClass = getFlagColorClass(day.flagCount);
-                      const tooltip = day.flagCount > 0
-                        ? `${day.dateStr}: ${day.flagTypes.join(' ')}`
-                        : `${day.dateStr}: normal`;
-                      return `<div class="calendar-square ${colorClass}" data-tooltip="${tooltip}" title="${tooltip}"><span class="calendar-square-day">${day.day}</span></div>`;
-                    }).join('')}
-                  </div>
-                </div>
-              `).join('')}
-            </div>
-            `;
-          }).join('')}
+          ${months.map((month) => renderMonthBlock(month, false)).join('')}
         </div>
       </div>
     </div>
   `;
-  return html;
 }
 
-// Render dashboard content: recent average, lifetime average, past three nights (timeline rows), sleep quality history.
+// Recommended sleep/wake window: recent average ± 30 minutes (same recent-days logic as dashboard).
+const PROJECTION_BAND_MINUTES = 30;
+
+function renderDashboardProjection(recentAverages) {
+  const sleepByLow = Math.max(0, recentAverages.avgBedtime - PROJECTION_BAND_MINUTES);
+  const sleepByHigh = Math.min(1440, recentAverages.avgBedtime + PROJECTION_BAND_MINUTES);
+  const wakeByLow = Math.max(0, recentAverages.avgSleepEnd - PROJECTION_BAND_MINUTES);
+  const wakeByHigh = Math.min(1440, recentAverages.avgSleepEnd + PROJECTION_BAND_MINUTES);
+
+  return `
+    <div class="dashboard-projection dashboard-projection--no-box">
+      <h2 class="dashboard-projection-title">Tonight</h2>
+      <p class="dashboard-projection-copy">(recommended per recent 3-day average ±${PROJECTION_BAND_MINUTES} min)</p>
+      <div class="dashboard-projection-grid">
+        <div class="dashboard-projection-item">
+          <span class="dashboard-projection-label"><span class="proj-keyword proj-sleep">🌙 Sleep</span> by</span>
+          <span class="dashboard-projection-range">${formatTime(sleepByLow)} – ${formatTime(sleepByHigh)}</span>
+        </div>
+        <div class="dashboard-projection-item dashboard-projection-item--wake">
+          <span class="dashboard-projection-label"><span class="proj-keyword proj-wake">🌅 Wake</span> by</span>
+          <span class="dashboard-projection-range">${formatTime(wakeByLow)} – ${formatTime(wakeByHigh)}</span>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+// Render dashboard content: projection, recent average, lifetime average, past three nights (timeline rows), sleep quality history.
 // Used by dashboard.html; kept here to share calculation/render helpers.
 function renderDashboardContent(days) {
   if (!days || days.length === 0) {
@@ -898,14 +974,14 @@ function renderDashboardContent(days) {
 
   const flagMap = buildFlagCountMap(days);
   const latestDataDate = getLatestDataDate(days, YEAR);
-  const calendarHeatmap = renderCalendarHeatmap(YEAR, flagMap, latestDataDate);
+  const calendarBlockOnly = renderCalendarCurrentMonthOnlyBlock(YEAR, flagMap, latestDataDate);
 
   const lastNightHtml = renderLastNightColumn(days[0]);
   const pastThreeCount = Math.min(3, days.length);
   const pastThreeNightsHtml = pastThreeCount > 0
     ? `
+    <h2 class="dashboard-section-title">Past three nights</h2>
     <section class="dashboard-past-nights">
-      <h2 class="dashboard-section-title">Past three nights</h2>
       <div class="week-days">
         ${Array.from({ length: pastThreeCount }, (_, i) => renderDay(days[i], days, i, { showTicks: true })).join('')}
       </div>
@@ -915,6 +991,15 @@ function renderDashboardContent(days) {
 
   return `
     <div class="dashboard-content">
+      <div class="dashboard-top-row">
+        <div class="dashboard-top-col dashboard-top-col--tonight">
+          ${renderDashboardProjection(recentAverages)}
+        </div>
+        <div class="dashboard-top-col dashboard-top-col--calendar">
+          ${calendarBlockOnly}
+        </div>
+      </div>
+      <h2 class="dashboard-section-title">Averages</h2>
       <div class="dashboard-averages-panel">
         <div class="averages-container">
           ${lastNightHtml}
@@ -923,7 +1008,6 @@ function renderDashboardContent(days) {
         </div>
       </div>
       ${pastThreeNightsHtml}
-      ${calendarHeatmap}
     </div>
   `;
 }

--- a/stats.js
+++ b/stats.js
@@ -167,7 +167,7 @@ function calculateMonthlyAverages(monthDays) {
     // Longest uninterrupted sleep
     longestUninterruptedSum += calculateLongestUninterrupted(day);
     
-    // First alarm to wake
+    // Alarm to wake
     const firstAlarmToWake = calculateFirstAlarmToWake(day);
     if (firstAlarmToWake !== null) {
       firstAlarmToWakeSum += firstAlarmToWake;


### PR DESCRIPTION
# Pull Request: dashboard-touchup

## Summary
Dashboard layout and sleep-quality UX improvements: new Quality page, current-month heatmap on dashboard, “Tonight” projection, and nav/docs updates.

---

## Changes (by significance)

- **New Sleep Quality page** — `quality.html` + `quality.js` add a dedicated view that shows the **full** sleep-quality calendar heatmap (all months). Dashboard now shows only the current month; full history lives here.
- **Dashboard redesign** — Top row: “Tonight” recommended window (sleep by / wake by from recent 3-day average ±30 min) plus current-month heatmap. Averages and “Past three nights” sections below. Cleaner section titles and layout.
- **Heatmap refactor in `sleep.js`** — Split rendering into `renderCalendarHeatmapCurrentMonthOnly()` (dashboard), `renderCalendarHeatmapFullHistory()` (quality page), shared `renderCalendarHeatmapHeader()` and `renderMonthBlock()`. Added `renderDashboardProjection()` for recommended sleep/wake bands.
- **New dashboard/projection styles in `sleep.css`** — Layout for top row, projection panel, inline calendar, and large calendar block. Timeline CSS vars updated (e.g. 20:00–20:00 window). New `--color-sunrise` and projection keyword styles.
- **Nav and docs** — Nav bar adds “Quality” (🟩) and shortens “Daily Timeline” to “Daily”. README updated: run instructions, data model (`days` array), Quality page section, file table, and `index.html` as entry point.
- **Data** — One new day (3/10) in `sleep-data.json`.
- **Comment tweaks** — `graph.html` and `stats.js`: “first alarm” → “alarm” in comments.