### PR TITLE
Dashboard, sleep tracking, stats, and styling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Static, client-side web app for logging and visualizing sleep (bed time, sleep s
 | **Frontend** | Vanilla HTML5, CSS3, JavaScript (no frameworks) |
 | **Data** | JSON files loaded via `fetch()` |
 | **Charts** | SVG drawn in JS (no chart library) |
-| **Styling** | Single `sleep.css` with CSS variables (dark theme) |
+| **Styling** | Single `styles.css` with CSS variables (dark theme) |
 
 - **Data source:** `sleep-data.json` (object with a `days` array of daily records) and `holidays.json` (year → month → list of holiday days).
 - **Shared logic:** `sleep-utils.js` holds time math, date helpers, and `renderNavBar()`. `sleep.js` holds dashboard/timeline/heatmap logic and is the main "core" script. Page-specific scripts: `dashboard.js`, `quality.js`, `graph.js`, `stats.js`.
@@ -81,7 +81,7 @@ Time is normalized as **minutes from midnight** (0–1440) everywhere, with expl
 
 ### UI
 - Shared **nav bar** via `renderNavBar(currentPage)` (Dashboard, Quality, Daily, Graphs, Stats).
-- Dark theme in `sleep.css` (e.g. `--bg`, `--panel`, `--color-sleep`, `--color-alarm`).
+- Dark theme in `styles.css` (e.g. `--bg`, `--panel`, `--color-sleep`, `--color-alarm`).
 - Tooltips and day panels for graph hover.
 
 ---
@@ -99,5 +99,5 @@ Time is normalized as **minutes from midnight** (0–1440) everywhere, with expl
 | `quality.js` | Fetches data and calls `renderCalendarHeatmapFullHistory()` for full history |
 | `graph.js` | Fetches data, regression, SVG line/bar charts |
 | `stats.js` | Monthly aggregation and stat rendering |
-| `sleep.css` | Global styles and CSS variables |
+| `styles.css` | Global styles and CSS variables |
 

--- a/dashboard-7d-graphs.js
+++ b/dashboard-7d-graphs.js
@@ -1,0 +1,391 @@
+// Dashboard 7-day graphs: time graph (left) and sleep duration chart (right).
+// Requires: sleep-utils.js (timeToMinutes, getDateFromString, calculateTotalSleep, formatDuration, formatTime)
+
+function normalizeTimeForYAxis(minutes) {
+  if (minutes < 1020) return minutes + 1440;
+  return minutes;
+}
+
+function calculateWakeDelay(day) {
+  if (!day.alarm || day.alarm.length === 0) return null;
+  const firstAlarm = Math.min(...day.alarm.map(timeToMinutes));
+  const wakeTime = timeToMinutes(day.sleepEnd);
+  let delay = wakeTime - firstAlarm;
+  if (delay < 0 && firstAlarm >= 1080) delay = (wakeTime + 1440) - firstAlarm;
+  return delay > 0 ? delay : null;
+}
+
+function calculateSleepDelay(day) {
+  const bedTime = timeToMinutes(day.bed);
+  const sleepStart = timeToMinutes(day.sleepStart);
+  let delay = sleepStart - bedTime;
+  if (delay < 0) delay += 1440;
+  return delay;
+}
+
+function solveLinearSystem(A, b) {
+  const n = A.length;
+  const augmented = A.map((row, i) => [...row, b[i]]);
+  for (let i = 0; i < n; i++) {
+    let maxRow = i;
+    for (let k = i + 1; k < n; k++) {
+      if (Math.abs(augmented[k][i]) > Math.abs(augmented[maxRow][i])) maxRow = k;
+    }
+    [augmented[i], augmented[maxRow]] = [augmented[maxRow], augmented[i]];
+    for (let k = i + 1; k < n; k++) {
+      const factor = augmented[k][i] / augmented[i][i];
+      for (let j = i; j <= n; j++) augmented[k][j] -= factor * augmented[i][j];
+    }
+  }
+  const x = new Array(n);
+  for (let i = n - 1; i >= 0; i--) {
+    x[i] = augmented[i][n];
+    for (let j = i + 1; j < n; j++) x[i] -= augmented[i][j] * x[j];
+    x[i] /= augmented[i][i];
+  }
+  return x;
+}
+
+function polynomialRegression(xValues, yValues, degree = 2) {
+  const n = xValues.length;
+  const X = [];
+  for (let i = 0; i < n; i++) {
+    const row = [];
+    for (let d = degree; d >= 0; d--) row.push(Math.pow(xValues[i], d));
+    X.push(row);
+  }
+  const XTX = [], XTY = [];
+  for (let i = 0; i <= degree; i++) {
+    XTX[i] = [];
+    XTY[i] = 0;
+    for (let j = 0; j <= degree; j++) {
+      let sum = 0;
+      for (let k = 0; k < n; k++) sum += X[k][i] * X[k][j];
+      XTX[i][j] = sum;
+    }
+    for (let k = 0; k < n; k++) XTY[i] += X[k][i] * yValues[k];
+  }
+  return solveLinearSystem(XTX, XTY);
+}
+
+function evaluatePolynomial(coefficients, x) {
+  let result = 0;
+  for (let i = 0; i < coefficients.length; i++)
+    result += coefficients[i] * Math.pow(x, coefficients.length - 1 - i);
+  return result;
+}
+
+function buildPoints(days) {
+  return days.map(day => {
+    const rawBed = timeToMinutes(day.bed);
+    const rawSleepStart = timeToMinutes(day.sleepStart);
+    const rawGetUp = timeToMinutes(day.sleepEnd);
+    const sleepDuration = calculateTotalSleep(day);
+    const sleepStart = timeToMinutes(day.sleepStart);
+    const sleepEnd = timeToMinutes(day.sleepEnd);
+    const mainSleep = sleepEnd >= sleepStart ? sleepEnd - sleepStart : sleepEnd + 1440 - sleepStart;
+    let napDuration = 0;
+    if (day.nap && day.nap.start && day.nap.end) {
+      const ns = timeToMinutes(day.nap.start), ne = timeToMinutes(day.nap.end);
+      napDuration = ne >= ns ? ne - ns : ne + 1440 - ns;
+    }
+    return {
+      date: getDateFromString(day.date),
+      bedTimeMinutes: normalizeTimeForYAxis(rawBed),
+      bedTimeString: day.bed,
+      sleepStartMinutes: normalizeTimeForYAxis(rawSleepStart),
+      sleepStartString: day.sleepStart,
+      getUpMinutes: normalizeTimeForYAxis(rawGetUp),
+      getUpString: day.sleepEnd,
+      dateString: day.date,
+      sleepDurationMinutes: sleepDuration,
+      mainSleepMinutes: mainSleep,
+      napMinutes: napDuration
+    };
+  });
+}
+
+function render7DayTimeGraph(container, points) {
+  if (!points.length) return;
+  const margin = { top: 24, right: 24, bottom: 36, left: 48 };
+  const width = Math.max(320, points.length * 36);
+  const height = 280;
+  const graphWidth = width - margin.left - margin.right;
+  const graphHeight = height - margin.top - margin.bottom;
+
+  // Dynamic Y range: min/max of 7-day data plus 1 hour on each side
+  const allTimes = points.flatMap(p => [p.bedTimeMinutes, p.sleepStartMinutes, p.getUpMinutes]);
+  const dataMin = Math.min(...allTimes), dataMax = Math.max(...allTimes);
+  const hourPad = 60;
+  const finalYMin = Math.floor((dataMin - hourPad) / 60) * 60;
+  const finalYMax = Math.ceil((dataMax + hourPad) / 60) * 60;
+  const range = Math.max(finalYMax - finalYMin, 120);
+
+  const minDate = points[0].date, maxDate = points[points.length - 1].date;
+  const dateRange = maxDate - minDate || 1;
+  const xScale = (date) => ((date - minDate) / dateRange) * graphWidth;
+  const yScale = (minutes) => graphHeight - ((minutes - finalYMin) / range) * graphHeight;
+
+  const yTicks = [];
+  for (let m = finalYMin; m <= finalYMax; m += 60) yTicks.push(m);
+  if (yTicks.length === 0) yTicks.push(finalYMin, finalYMax);
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', width);
+  svg.setAttribute('height', height);
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  g.setAttribute('transform', `translate(${margin.left},${margin.top})`);
+  svg.appendChild(g);
+
+  const ns = (tag) => document.createElementNS('http://www.w3.org/2000/svg', tag);
+  const addLine = (x1, y1, x2, y2, cls) => {
+    const line = ns('line');
+    line.setAttribute('x1', x1); line.setAttribute('y1', y1);
+    line.setAttribute('x2', x2); line.setAttribute('y2', y2);
+    if (cls) line.setAttribute('class', cls);
+    g.appendChild(line);
+  };
+  const addText = (x, y, text, anchor = 'middle') => {
+    const el = ns('text');
+    el.setAttribute('x', x); el.setAttribute('y', y);
+    el.setAttribute('class', 'axis-label');
+    el.setAttribute('text-anchor', anchor);
+    el.textContent = text;
+    g.appendChild(el);
+  };
+
+  yTicks.forEach(tick => {
+    const y = yScale(tick);
+    addLine(0, y, graphWidth, y, 'grid-line');
+  });
+
+  addLine(0, graphHeight, graphWidth, graphHeight, 'axis');
+  addLine(0, 0, 0, graphHeight, 'axis');
+  addLine(graphWidth, 0, graphWidth, graphHeight, 'axis');
+
+  // Left Y-axis labels only
+  yTicks.forEach(tick => {
+    const y = yScale(tick);
+    addLine(-5, y, 0, y, 'axis');
+    const label = ns('text');
+    label.setAttribute('x', -8);
+    label.setAttribute('y', y + 4);
+    label.setAttribute('class', 'axis-label');
+    label.setAttribute('text-anchor', 'end');
+    label.textContent = tick >= 1440 ? String(Math.floor((tick - 1440) / 60)).padStart(2, '0') : String(Math.floor(tick / 60)).padStart(2, '0');
+    g.appendChild(label);
+  });
+
+  points.forEach((point, index) => {
+    const [month, day] = point.dateString.split('/').map(Number);
+    const x = xScale(point.date);
+    const tickLine = ns('line');
+    tickLine.setAttribute('x1', x); tickLine.setAttribute('y1', graphHeight);
+    tickLine.setAttribute('x2', x); tickLine.setAttribute('y2', graphHeight + 5);
+    tickLine.setAttribute('class', 'axis');
+    g.appendChild(tickLine);
+    const label = ns('text');
+    label.setAttribute('x', x);
+    label.setAttribute('y', graphHeight + 14);
+    label.setAttribute('class', 'axis-label');
+    label.setAttribute('text-anchor', 'middle');
+    label.textContent = `${month}/${day}`;
+    g.appendChild(label);
+  });
+
+  const path = (pts, key) => {
+    let d = '';
+    pts.forEach((p, i) => {
+      const x = xScale(p.date), y = yScale(p[key]);
+      d += (i ? ' L ' : 'M ') + x + ' ' + y;
+    });
+    return d;
+  };
+
+  const pathBedtime = ns('path');
+  pathBedtime.setAttribute('d', path(points, 'bedTimeMinutes'));
+  pathBedtime.setAttribute('class', 'data-line bedtime');
+  g.appendChild(pathBedtime);
+  const pathSleepStart = ns('path');
+  pathSleepStart.setAttribute('d', path(points, 'sleepStartMinutes'));
+  pathSleepStart.setAttribute('class', 'data-line sleep-start');
+  g.appendChild(pathSleepStart);
+  const pathGetUp = ns('path');
+  pathGetUp.setAttribute('d', path(points, 'getUpMinutes'));
+  pathGetUp.setAttribute('class', 'data-line getup');
+  g.appendChild(pathGetUp);
+
+  const getUpReg = polynomialRegression(points.map((_, i) => i), points.map(p => p.getUpMinutes), 2);
+  const sleepStartReg = polynomialRegression(points.map((_, i) => i), points.map(p => p.sleepStartMinutes), 2);
+  const bedtimeReg = polynomialRegression(points.map((_, i) => i), points.map(p => p.bedTimeMinutes), 2);
+
+  const regPath = (coeffs, key) => {
+    let d = '';
+    points.forEach((p, i) => {
+      const x = xScale(p.date), y = yScale(evaluatePolynomial(coeffs, i));
+      d += (i ? ' L ' : 'M ') + x + ' ' + y;
+    });
+    return d;
+  };
+  const regGetUp = ns('path');
+  regGetUp.setAttribute('d', regPath(getUpReg, 'getUpMinutes'));
+  regGetUp.setAttribute('class', 'regression-line getup-regression');
+  regGetUp.setAttribute('fill', 'none');
+  g.appendChild(regGetUp);
+  const regSleepStart = ns('path');
+  regSleepStart.setAttribute('d', regPath(sleepStartReg, 'sleepStartMinutes'));
+  regSleepStart.setAttribute('class', 'regression-line sleep-start-regression');
+  regSleepStart.setAttribute('fill', 'none');
+  g.appendChild(regSleepStart);
+  const regBedtime = ns('path');
+  regBedtime.setAttribute('d', regPath(bedtimeReg, 'bedTimeMinutes'));
+  regBedtime.setAttribute('class', 'regression-line bedtime-regression');
+  regBedtime.setAttribute('fill', 'none');
+  g.appendChild(regBedtime);
+
+  points.forEach(p => {
+    ['bedTimeMinutes', 'sleepStartMinutes', 'getUpMinutes'].forEach((key, i) => {
+      const circle = ns('circle');
+      circle.setAttribute('cx', xScale(p.date));
+      circle.setAttribute('cy', yScale(p[key]));
+      circle.setAttribute('r', 3);
+      circle.setAttribute('class', 'data-point ' + (key === 'bedTimeMinutes' ? 'bedtime' : key === 'sleepStartMinutes' ? 'sleep-start' : 'getup'));
+      g.appendChild(circle);
+    });
+  });
+
+  container.innerHTML = '';
+  container.appendChild(svg);
+}
+
+function render7DayDurationChart(container, points) {
+  if (!points.length) return;
+  const margin = { top: 24, right: 24, bottom: 36, left: 48 };
+  const width = Math.max(320, points.length * 36);
+  const height = 280;
+  const graphWidth = width - margin.left - margin.right;
+  const graphHeight = height - margin.top - margin.bottom;
+
+  const minDate = points[0].date, maxDate = points[points.length - 1].date;
+  const dateRange = maxDate - minDate || 1;
+  const xScale = (date) => ((date - minDate) / dateRange) * graphWidth;
+
+  // Dynamic Y range: min/max sleep duration in 7 days plus 1 hour on each side
+  const allDurations = points.map(p => p.sleepDurationMinutes);
+  const dataMin = Math.min(...allDurations), dataMax = Math.max(...allDurations);
+  const hourPad = 60;
+  const sleepYMin = Math.floor((dataMin - hourPad) / 60) * 60;
+  const sleepYMax = Math.ceil((dataMax + hourPad) / 60) * 60;
+  const sleepRange = Math.max(sleepYMax - sleepYMin, 120);
+  const sleepYScale = (minutes) => graphHeight - ((minutes - sleepYMin) / sleepRange) * graphHeight;
+
+  const sleepYTicks = [];
+  for (let m = sleepYMin; m <= sleepYMax; m += 60) sleepYTicks.push(m);
+  if (sleepYTicks.length === 0) sleepYTicks.push(sleepYMin, sleepYMax);
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', width);
+  svg.setAttribute('height', height);
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  g.setAttribute('transform', `translate(${margin.left},${margin.top})`);
+  svg.appendChild(g);
+
+  const ns = (tag) => document.createElementNS('http://www.w3.org/2000/svg', tag);
+
+  sleepYTicks.forEach(tick => {
+    const y = sleepYScale(tick);
+    const line = ns('line');
+    line.setAttribute('x1', 0); line.setAttribute('y1', y);
+    line.setAttribute('x2', graphWidth); line.setAttribute('y2', y);
+    line.setAttribute('class', 'grid-line');
+    g.appendChild(line);
+  });
+
+  const addLine = (x1, y1, x2, y2, cls) => {
+    const line = ns('line');
+    line.setAttribute('x1', x1); line.setAttribute('y1', y1);
+    line.setAttribute('x2', x2); line.setAttribute('y2', y2);
+    if (cls) line.setAttribute('class', cls);
+    g.appendChild(line);
+  };
+  addLine(0, graphHeight, graphWidth, graphHeight, 'axis');
+  addLine(0, 0, 0, graphHeight, 'axis');
+  addLine(graphWidth, 0, graphWidth, graphHeight, 'axis');
+
+  // Left Y-axis labels only
+  sleepYTicks.forEach(tick => {
+    const y = sleepYScale(tick);
+    addLine(-5, y, 0, y, 'axis');
+    const label = ns('text');
+    label.setAttribute('x', -8); label.setAttribute('y', y + 4);
+    label.setAttribute('class', 'axis-label'); label.setAttribute('text-anchor', 'end');
+    label.textContent = `${tick / 60}h`;
+    g.appendChild(label);
+  });
+
+  points.forEach(point => {
+    const [month, day] = point.dateString.split('/').map(Number);
+    const x = xScale(point.date);
+    const tickLine = ns('line');
+    tickLine.setAttribute('x1', x); tickLine.setAttribute('y1', graphHeight);
+    tickLine.setAttribute('x2', x); tickLine.setAttribute('y2', graphHeight + 5);
+    tickLine.setAttribute('class', 'axis');
+    g.appendChild(tickLine);
+    const label = ns('text');
+    label.setAttribute('x', x); label.setAttribute('y', graphHeight + 14);
+    label.setAttribute('class', 'axis-label'); label.setAttribute('text-anchor', 'middle');
+    label.textContent = `${month}/${day}`;
+    g.appendChild(label);
+  });
+
+  const dayWidth = graphWidth / Math.max(1, points.length);
+  const barWidth = Math.max(2, dayWidth * 0.8);
+  points.forEach(point => {
+    const x = xScale(point.date);
+    const mainSleepBarY = sleepYScale(point.mainSleepMinutes);
+    const mainRect = ns('rect');
+    mainRect.setAttribute('x', x - barWidth / 2);
+    mainRect.setAttribute('y', mainSleepBarY);
+    mainRect.setAttribute('width', barWidth);
+    mainRect.setAttribute('height', graphHeight - mainSleepBarY);
+    mainRect.setAttribute('class', 'sleep-bar');
+    g.appendChild(mainRect);
+    if (point.napMinutes > 0) {
+      const napBarY = sleepYScale(point.sleepDurationMinutes);
+      const napRect = ns('rect');
+      napRect.setAttribute('x', x - barWidth / 2);
+      napRect.setAttribute('y', napBarY);
+      napRect.setAttribute('width', barWidth);
+      napRect.setAttribute('height', mainSleepBarY - napBarY);
+      napRect.setAttribute('class', 'sleep-bar nap-bar');
+      g.appendChild(napRect);
+    }
+  });
+
+  const sleepReg = polynomialRegression(points.map((_, i) => i), points.map(p => p.sleepDurationMinutes), 2);
+  let trendD = '';
+  points.forEach((p, i) => {
+    const x = xScale(p.date), y = sleepYScale(evaluatePolynomial(sleepReg, i));
+    trendD += (i ? ' L ' : 'M ') + x + ' ' + y;
+  });
+  const trendPath = ns('path');
+  trendPath.setAttribute('d', trendD);
+  trendPath.setAttribute('class', 'regression-line sleep-trend');
+  trendPath.setAttribute('fill', 'none');
+  g.appendChild(trendPath);
+
+  container.innerHTML = '';
+  container.appendChild(svg);
+}
+
+function renderDashboard7DayGraphs(days) {
+  if (!days || days.length === 0) return;
+  const points = buildPoints(days);
+  points.sort((a, b) => a.date - b.date);
+  const last7 = points.slice(-7);
+  if (last7.length === 0) return;
+  const timeEl = document.getElementById('dashboard-7d-time-graph');
+  const durationEl = document.getElementById('dashboard-7d-duration-graph');
+  if (timeEl) render7DayTimeGraph(timeEl, last7);
+  if (durationEl) render7DayDurationChart(durationEl, last7);
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Dashboard</title>
-<link rel="stylesheet" href="sleep.css">
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div id="nav-container"></div>
@@ -13,9 +14,11 @@
 
   <script src="sleep-utils.js"></script>
   <script src="sleep.js"></script>
+  <script src="dashboard-7d-graphs.js"></script>
   <script src="dashboard.js"></script>
   <script>
     document.getElementById('nav-container').innerHTML = renderNavBar('dashboard');
+    initDayNightTheme();
   </script>
 </body>
 </html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -10,6 +10,9 @@ if (dashboardContainer) {
     .then(([sleepData, holidaysData]) => {
       if (typeof holidays !== 'undefined') holidays = holidaysData;
       dashboardContainer.innerHTML = renderDashboardContent(sleepData.days);
+      if (typeof renderDashboard7DayGraphs === 'function') {
+        renderDashboard7DayGraphs(sleepData.days);
+      }
     })
     .catch(error => {
       console.error('Error loading dashboard data:', error);

--- a/graph.html
+++ b/graph.html
@@ -2,14 +2,15 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sleep Graph</title>
-<link rel="stylesheet" href="sleep.css">
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div id="nav-container"></div>
   <div class="container">
-    <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 20px; flex-wrap: wrap; gap: 20px;">
-      <h1 style="margin: 0;">Sleep Graph</h1>
+    <div class="graph-page-header">
+      <h1>Sleep Graph</h1>
       <div class="show-hide-section">
         <div class="show-hide-title">show/hide</div>
         <label class="time-toggle">
@@ -47,10 +48,10 @@
     <div class="graph-container" id="graph-container">
       <svg id="graph-svg"></svg>
     </div>
-    <div class="graph-container" id="bar-chart-container" style="margin-top: 40px;">
+    <div class="graph-container chart-section" id="bar-chart-container">
       <svg id="bar-chart-svg"></svg>
     </div>
-    <div class="graph-container" id="delay-chart-container" style="margin-top: 40px;">
+    <div class="graph-container chart-section" id="delay-chart-container">
       <svg id="delay-chart-svg"></svg>
     </div>
   </div>
@@ -61,6 +62,7 @@
   <script>
     // Add navigation bar
     document.getElementById('nav-container').innerHTML = renderNavBar('graph');
+    initDayNightTheme();
     // Note: timeToMinutes and formatTime are now in sleep-utils.js
     // Use formatTime(minutes, true) for short midnight format ("00")
 
@@ -944,7 +946,7 @@
         barChartYAxis.setAttribute('class', 'axis');
         barChartG.appendChild(barChartYAxis);
 
-        // Draw Y-axis labels and ticks for bar chart
+        // Draw Y-axis labels and ticks for bar chart (left)
         sleepYTicks.forEach(tick => {
           const y = sleepYScale(tick);
           const tickLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
@@ -960,6 +962,34 @@
           label.setAttribute('y', y + 4);
           label.setAttribute('class', 'axis-label');
           label.setAttribute('text-anchor', 'end');
+          label.textContent = `${tick / 60}h`;
+          barChartG.appendChild(label);
+        });
+
+        // Draw right Y-axis line and labels for bar chart (same as time-to-bed graph)
+        const barChartYAxisRight = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        barChartYAxisRight.setAttribute('x1', barChartGraphWidth);
+        barChartYAxisRight.setAttribute('y1', 0);
+        barChartYAxisRight.setAttribute('x2', barChartGraphWidth);
+        barChartYAxisRight.setAttribute('y2', barChartGraphHeight);
+        barChartYAxisRight.setAttribute('class', 'axis');
+        barChartG.appendChild(barChartYAxisRight);
+
+        sleepYTicks.forEach(tick => {
+          const y = sleepYScale(tick);
+          const tickLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          tickLine.setAttribute('x1', barChartGraphWidth);
+          tickLine.setAttribute('y1', y);
+          tickLine.setAttribute('x2', barChartGraphWidth + 5);
+          tickLine.setAttribute('y2', y);
+          tickLine.setAttribute('class', 'axis');
+          barChartG.appendChild(tickLine);
+
+          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          label.setAttribute('x', barChartGraphWidth + 10);
+          label.setAttribute('y', y + 4);
+          label.setAttribute('class', 'axis-label');
+          label.setAttribute('text-anchor', 'start');
           label.textContent = `${tick / 60}h`;
           barChartG.appendChild(label);
         });
@@ -1103,7 +1133,7 @@
         } catch (barChartError) {
           console.error('Error rendering bar chart:', barChartError);
           const errorDiv = document.createElement('div');
-          errorDiv.style.cssText = 'color: red; padding: 10px; background: rgba(255,0,0,0.1); margin: 10px 0;';
+          errorDiv.className = 'chart-error';
           errorDiv.textContent = 'Bar chart error: ' + barChartError.message;
           document.getElementById('bar-chart-container').appendChild(errorDiv);
         }
@@ -1202,7 +1232,7 @@
         delayChartYAxis.setAttribute('class', 'axis');
         delayChartG.appendChild(delayChartYAxis);
 
-        // Draw Y-axis labels and ticks for delay chart
+        // Draw Y-axis labels and ticks for delay chart (left)
         delayYTicks.forEach(tick => {
           const y = delayYScale(tick);
           const tickLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
@@ -1219,6 +1249,38 @@
           label.setAttribute('class', 'axis-label');
           label.setAttribute('text-anchor', 'end');
           // Show negative values with absolute value (e.g., -1h shows as "1")
+          if (tick < 0) {
+            label.textContent = `${Math.abs(tick / 60)}`;
+          } else {
+            label.textContent = `${tick / 60}h`;
+          }
+          delayChartG.appendChild(label);
+        });
+
+        // Draw right Y-axis line and labels for delay chart (same as time-to-bed graph)
+        const delayChartYAxisRight = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        delayChartYAxisRight.setAttribute('x1', delayChartGraphWidth);
+        delayChartYAxisRight.setAttribute('y1', maxNegativeY);
+        delayChartYAxisRight.setAttribute('x2', delayChartGraphWidth);
+        delayChartYAxisRight.setAttribute('y2', maxPositiveY);
+        delayChartYAxisRight.setAttribute('class', 'axis');
+        delayChartG.appendChild(delayChartYAxisRight);
+
+        delayYTicks.forEach(tick => {
+          const y = delayYScale(tick);
+          const tickLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          tickLine.setAttribute('x1', delayChartGraphWidth);
+          tickLine.setAttribute('y1', y);
+          tickLine.setAttribute('x2', delayChartGraphWidth + 5);
+          tickLine.setAttribute('y2', y);
+          tickLine.setAttribute('class', 'axis');
+          delayChartG.appendChild(tickLine);
+
+          const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+          label.setAttribute('x', delayChartGraphWidth + 10);
+          label.setAttribute('y', y + 4);
+          label.setAttribute('class', 'axis-label');
+          label.setAttribute('text-anchor', 'start');
           if (tick < 0) {
             label.textContent = `${Math.abs(tick / 60)}`;
           } else {
@@ -1419,7 +1481,7 @@
         } catch (delayChartError) {
           console.error('Error rendering delay chart:', delayChartError);
           const errorDiv = document.createElement('div');
-          errorDiv.style.cssText = 'color: red; padding: 10px; background: rgba(255,0,0,0.1); margin: 10px 0;';
+          errorDiv.className = 'chart-error';
           errorDiv.textContent = 'Delay chart error: ' + delayChartError.message;
           document.getElementById('delay-chart-container').appendChild(errorDiv);
         }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="refresh" content="0; url=dashboard.html">
   <title>Redirecting...</title>
 </head>

--- a/quality.html
+++ b/quality.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sleep Quality History</title>
-<link rel="stylesheet" href="sleep.css">
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div id="nav-container"></div>
@@ -16,6 +17,7 @@
   <script src="quality.js"></script>
   <script>
     document.getElementById('nav-container').innerHTML = renderNavBar('quality');
+    initDayNightTheme();
   </script>
 </body>
 </html>

--- a/sleep-data.json
+++ b/sleep-data.json
@@ -1,6 +1,16 @@
 {
   "days": [
     {
+      "date": "3/11",
+      "bed": "22:00",
+      "sleepStart": "22:40",
+      "sleepEnd": "7:13",
+      "bathroom": ["5:20"],
+      "alarm": ["6:50"],
+      "sick": [],
+      "nap": null
+    },
+    {
       "date": "3/10",
       "bed": "21:33",
       "sleepStart": "22:00",

--- a/sleep-utils.js
+++ b/sleep-utils.js
@@ -121,8 +121,109 @@ function normalizeTimeForComparison(minutes) {
 // Project repo (used in nav bar)
 const GITHUB_REPO_URL = 'https://github.com/rsairu/sleep/';
 
+// Day/night mode: sunrise and sunset in local time (hours 0-23, minutes 0-59)
+const SUNRISE_HOUR = 6;
+const SUNRISE_MINUTE = 0;
+const SUNSET_HOUR = 18;
+const SUNSET_MINUTE = 0;
+
+const THEME_OVERRIDE_KEY = 'sleep-app-theme-override';
+
+// Returns 'day' if current local time is between sunrise and sunset, else 'night'
+function getThemeFromTime() {
+  const now = new Date();
+  const minutesSinceMidnight = now.getHours() * 60 + now.getMinutes();
+  const sunriseMinutes = SUNRISE_HOUR * 60 + SUNRISE_MINUTE;
+  const sunsetMinutes = SUNSET_HOUR * 60 + SUNSET_MINUTE;
+  return minutesSinceMidnight >= sunriseMinutes && minutesSinceMidnight < sunsetMinutes ? 'day' : 'night';
+}
+
+// Returns current theme override from localStorage ('day' | 'night' | null)
+function getThemeOverride() {
+  try {
+    const v = localStorage.getItem(THEME_OVERRIDE_KEY);
+    return v === 'day' || v === 'night' ? v : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+// Sets theme override and saves to localStorage (null = auto)
+function setThemeOverride(theme) {
+  try {
+    if (theme === null) localStorage.removeItem(THEME_OVERRIDE_KEY);
+    else localStorage.setItem(THEME_OVERRIDE_KEY, theme);
+  } catch (_) {}
+}
+
+// Effective theme: override if set, otherwise from time
+function getEffectiveTheme() {
+  const override = getThemeOverride();
+  return override !== null ? override : getThemeFromTime();
+}
+
+// Applies day or night theme to the document; uses override if set. Returns effective theme.
+function applyDayNightTheme() {
+  const theme = getEffectiveTheme();
+  document.documentElement.dataset.theme = theme;
+  return theme;
+}
+
+// Sun icon: filled circle + rays (visible when filled)
+const SUN_ICON = '<svg class="nav-daynight-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303l-1.591 1.59a.75.75 0 001.06-1.061l1.591-1.59a.75.75 0 00-1.06-1.06zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591a.75.75 0 001.061-1.06z"/></svg>';
+const MOON_ICON = '<svg class="nav-daynight-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/></svg>';
+
+function getDayNightTitle(theme, isOverride) {
+  if (theme === 'day') return isOverride ? 'Day mode (manual) — click to change' : 'Day mode (auto) — click to change';
+  return isOverride ? 'Night mode (manual) — click to change' : 'Night mode (auto) — click to change';
+}
+
+// Returns HTML for the day/night indicator icon (sun or moon)
+function getDayNightIconHTML(theme) {
+  const isOverride = getThemeOverride() !== null;
+  const title = getDayNightTitle(theme, isOverride);
+  const svg = theme === 'day' ? SUN_ICON : MOON_ICON;
+  return `<span id="nav-daynight" class="nav-daynight" role="button" title="${title}" aria-label="${title}">${svg}</span>`;
+}
+
+// Updates the nav daynight icon if the element exists (e.g. after theme tick or click)
+function updateDayNightIcon() {
+  const el = document.getElementById('nav-daynight');
+  if (!el) return;
+  const theme = getEffectiveTheme();
+  const isOverride = getThemeOverride() !== null;
+  el.title = getDayNightTitle(theme, isOverride);
+  el.innerHTML = theme === 'day' ? SUN_ICON : MOON_ICON;
+}
+
+// Cycle theme on icon click: auto -> day -> night -> auto
+function handleDayNightClick() {
+  const override = getThemeOverride();
+  const next = override === null ? 'day' : override === 'day' ? 'night' : null;
+  if (next === null) setThemeOverride(null);
+  else setThemeOverride(next);
+  applyDayNightTheme();
+  updateDayNightIcon();
+}
+
+// Initializes day/night theme, click handler, and timer to re-check (when in auto mode)
+function initDayNightTheme() {
+  applyDayNightTheme();
+  updateDayNightIcon();
+  const el = document.getElementById('nav-daynight');
+  if (el) el.addEventListener('click', handleDayNightClick);
+  setInterval(function () {
+    applyDayNightTheme();
+    updateDayNightIcon();
+  }, 60000);
+}
+
 // Render navigation bar
 function renderNavBar(currentPage) {
+  applyDayNightTheme();
+  const theme = getThemeFromTime();
+  const dayNightIcon = getDayNightIconHTML(theme);
+
   const pages = [
     { id: 'dashboard', name: 'Dashboard', url: 'dashboard.html', icon: '🛌' },
     { id: 'quality', name: 'Quality', url: 'quality.html', icon: '🟩' },
@@ -138,6 +239,7 @@ function renderNavBar(currentPage) {
 
   const githubIcon = `<svg class="nav-github-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`;
   const githubLink = `<a href="${GITHUB_REPO_URL}" class="nav-github-link" target="_blank" rel="noopener noreferrer" title="View on GitHub">${githubIcon}</a>`;
+  const navRight = `<div class="nav-right">${dayNightIcon}${githubLink}</div>`;
 
-  return `<div class="nav-bar"><div class="nav-tabs">${navItems}</div>${githubLink}</div>`;
+  return `<div class="nav-bar"><div class="nav-tabs">${navItems}</div>${navRight}</div>`;
 }

--- a/sleep.html
+++ b/sleep.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Daily timeline</title>
-<link rel="stylesheet" href="sleep.css">
+<link rel="stylesheet" href="styles.css">
 </head>
 
 <body>
@@ -18,6 +19,7 @@
   <script>
     // Add navigation bar
     document.getElementById('nav-container').innerHTML = renderNavBar('timeline');
+    initDayNightTheme();
   </script>
 </body>
 </html>

--- a/sleep.js
+++ b/sleep.js
@@ -518,6 +518,12 @@ function renderDay(day, days, dayIndex, options) {
     <div class="day ${dayClasses.join(' ')}">
       <div class="day-content">
         <div class="day-date">${day.date} ${dayOfWeek}${isHolidayDay ? ' 🎉' : ''}</div>
+        <div class="day-stats">
+          <div class="stat-row"><span class="stat-label">${highlightKeyword('fell asleep:', 'asleep')}</span><span class="stat-value">${day.sleepStart}</span></div>
+          <div class="stat-row"><span class="stat-label">${highlightKeyword('sleep duration:', 'sleep')}</span><span class="stat-value">${formatDuration(sleepDuration)}</span></div>
+          <div class="stat-row"><span class="stat-label">longest uninterrupted:</span><span class="stat-value">${formatDuration(longestUninterrupted)}</span></div>
+          ${firstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${firstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(firstAlarmToWake)}</span></div>` : ''}
+        </div>
         <div class="day-bar-container">
           <div class="${barClass}">
             <!-- Faded overlay for previous day section (22:00-00:00) -->
@@ -554,12 +560,6 @@ function renderDay(day, days, dayIndex, options) {
   html += `<div class="event up" style="--m:${upPos}" data-tooltip="${day.sleepEnd} get up"></div>`;
   
   html += `</div></div>
-        <div class="day-stats">
-          <div class="stat-row"><span class="stat-label">${highlightKeyword('fell asleep:', 'asleep')}</span><span class="stat-value">${day.sleepStart}</span></div>
-          <div class="stat-row"><span class="stat-label">${highlightKeyword('sleep duration:', 'sleep')}</span><span class="stat-value">${formatDuration(sleepDuration)}</span></div>
-          <div class="stat-row"><span class="stat-label">longest uninterrupted:</span><span class="stat-value">${formatDuration(longestUninterrupted)}</span></div>
-          ${firstAlarmToWake !== null ? `<div class="stat-row"><span class="stat-label">${highlightKeyword('alarm to wake:', ['alarm', 'wake'])}</span><span class="stat-value ${firstAlarmToWake > ALARM_TO_WAKE_WARNING_THRESHOLD ? 'stat-warning' : ''}">${formatDuration(firstAlarmToWake)}</span></div>` : ''}
-        </div>
       </div>
       ${deviationWarnings}
     </div>`;
@@ -621,6 +621,22 @@ function renderAveragesColumn(averages, title) {
   `;
 }
 
+// Render top averages for stats page: recent (left) and lifetime (right) in split columns
+function renderStatsTopAverages(days) {
+  if (!days || days.length === 0) return '';
+  const recentDays = days.slice(0, Math.min(3, days.length));
+  const recentAverages = calculateAverages(recentDays);
+  const lifetimeAverages = calculateAverages(days);
+  return `
+    <div class="dashboard-averages-panel stats-top-averages">
+      <div class="averages-container">
+        ${renderAveragesColumn(recentAverages, '🕒 Recent average (3 days)')}
+        ${renderAveragesColumn(lifetimeAverages, '🌳 Lifetime average')}
+      </div>
+    </div>
+  `;
+}
+
 // Render last night column (single day: fell asleep, duration, longest uninterrupted, alarm to wake)
 function renderLastNightColumn(day) {
   const sleepDuration = calculateTotalSleep(day);
@@ -650,15 +666,16 @@ function renderWeekSummary(days) {
   
   return `
     <div class="week-summary">
+      <div class="week-summary-spacer"></div>
+      <div class="day-stats">
+        ${renderAveragesStats(averages)}
+      </div>
       <div class="week-summary-bar">
         <div class="bar">
           <div class="previous-day-overlay"></div>
           <div class="span sleep" style="--start:${avgSleepStartPos}; --end:${avgSleepEndPos}" data-tooltip="average sleep: ${formatTime(avgSleepStart)} - ${formatTime(avgSleepEnd)}"></div>
           ${TIME_TICKS.map((minutes, i) => `<div class="time-tick" style="--m:${minutes}"><span class="tick-label">${tickLabels[i]}</span></div>`).join('')}
         </div>
-      </div>
-      <div class="day-stats">
-        ${renderAveragesStats(averages)}
       </div>
     </div>
   `;
@@ -944,20 +961,39 @@ function renderDashboardProjection(recentAverages) {
   const wakeByLow = Math.max(0, recentAverages.avgSleepEnd - PROJECTION_BAND_MINUTES);
   const wakeByHigh = Math.min(1440, recentAverages.avgSleepEnd + PROJECTION_BAND_MINUTES);
 
+  const sleepTarget = recentAverages.avgBedtime;
+  const wakeTarget = recentAverages.avgSleepEnd;
+  const recommendedDurationMins = wakeTarget >= sleepTarget
+    ? wakeTarget - sleepTarget
+    : 1440 - sleepTarget + wakeTarget;
+
   return `
     <div class="dashboard-projection dashboard-projection--no-box">
-      <h2 class="dashboard-projection-title">Tonight</h2>
-      <p class="dashboard-projection-copy">(recommended per recent 3-day average ±${PROJECTION_BAND_MINUTES} min)</p>
+      <h2 class="dashboard-projection-title">Recommended tonight</h2>
+      <p class="dashboard-projection-copy">(recent three-day average ± ${PROJECTION_BAND_MINUTES} min)</p>
       <div class="dashboard-projection-grid">
         <div class="dashboard-projection-item">
-          <span class="dashboard-projection-label"><span class="proj-keyword proj-sleep">🌙 Sleep</span> by</span>
-          <span class="dashboard-projection-range">${formatTime(sleepByLow)} – ${formatTime(sleepByHigh)}</span>
+          <span class="dashboard-projection-label"><span class="proj-keyword proj-sleep">🌙 Sleep</span></span>
+          <div class="dashboard-projection-row">
+            <span class="dashboard-projection-bounds">${formatTime(sleepByLow)}</span>
+            <span class="dashboard-projection-sep">—</span>
+            <span class="dashboard-projection-target">${formatTime(sleepTarget)}</span>
+            <span class="dashboard-projection-sep">—</span>
+            <span class="dashboard-projection-bounds">${formatTime(sleepByHigh)}</span>
+          </div>
         </div>
         <div class="dashboard-projection-item dashboard-projection-item--wake">
-          <span class="dashboard-projection-label"><span class="proj-keyword proj-wake">🌅 Wake</span> by</span>
-          <span class="dashboard-projection-range">${formatTime(wakeByLow)} – ${formatTime(wakeByHigh)}</span>
+          <span class="dashboard-projection-label"><span class="proj-keyword proj-wake">🌅 Wake</span></span>
+          <div class="dashboard-projection-row">
+            <span class="dashboard-projection-bounds">${formatTime(wakeByLow)}</span>
+            <span class="dashboard-projection-sep">—</span>
+            <span class="dashboard-projection-target">${formatTime(wakeTarget)}</span>
+            <span class="dashboard-projection-sep">—</span>
+            <span class="dashboard-projection-bounds">${formatTime(wakeByHigh)}</span>
+          </div>
         </div>
       </div>
+      <p class="dashboard-projection-duration">(~${formatDuration(recommendedDurationMins)} sleep)</p>
     </div>
   `;
 }
@@ -968,7 +1004,6 @@ function renderDashboardContent(days) {
   if (!days || days.length === 0) {
     return '<p>No sleep data yet.</p>';
   }
-  const lifetimeAverages = calculateAverages(days);
   const recentDays = days.slice(0, Math.min(3, days.length));
   const recentAverages = calculateAverages(recentDays);
 
@@ -976,7 +1011,6 @@ function renderDashboardContent(days) {
   const latestDataDate = getLatestDataDate(days, YEAR);
   const calendarBlockOnly = renderCalendarCurrentMonthOnlyBlock(YEAR, flagMap, latestDataDate);
 
-  const lastNightHtml = renderLastNightColumn(days[0]);
   const pastThreeCount = Math.min(3, days.length);
   const pastThreeNightsHtml = pastThreeCount > 0
     ? `
@@ -989,6 +1023,18 @@ function renderDashboardContent(days) {
     `
     : '';
 
+  const sevenDaySectionHtml = `
+    <h2 class="dashboard-section-title">Last 7 days</h2>
+    <div class="dashboard-7d-row">
+      <div class="dashboard-7d-col">
+        <div class="dashboard-7d-graph-container" id="dashboard-7d-time-graph"></div>
+      </div>
+      <div class="dashboard-7d-col">
+        <div class="dashboard-7d-graph-container" id="dashboard-7d-duration-graph"></div>
+      </div>
+    </div>
+  `;
+
   return `
     <div class="dashboard-content">
       <div class="dashboard-top-row">
@@ -999,14 +1045,7 @@ function renderDashboardContent(days) {
           ${calendarBlockOnly}
         </div>
       </div>
-      <h2 class="dashboard-section-title">Averages</h2>
-      <div class="dashboard-averages-panel">
-        <div class="averages-container">
-          ${lastNightHtml}
-          ${renderAveragesColumn(recentAverages, '🕒 Recent average (3 days)')}
-          ${renderAveragesColumn(lifetimeAverages, '🌳 Lifetime average')}
-        </div>
-      </div>
+      ${sevenDaySectionHtml}
       ${pastThreeNightsHtml}
     </div>
   `;

--- a/stats.html
+++ b/stats.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sleep Stats</title>
-<link rel="stylesheet" href="sleep.css">
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div id="nav-container"></div>
@@ -13,10 +14,12 @@
   </div>
 
   <script src="sleep-utils.js"></script>
+  <script src="sleep.js"></script>
   <script src="stats.js"></script>
   <script>
     // Add navigation bar
     document.getElementById('nav-container').innerHTML = renderNavBar('stats');
+    initDayNightTheme();
   </script>
 </body>
 </html>

--- a/stats.js
+++ b/stats.js
@@ -599,7 +599,10 @@ Promise.all([
       renderMonthlyStats(monthData, monthStats, index)
     ).join('');
     
-    document.getElementById('stats-container').innerHTML = statsHtml;
+    const topAveragesHtml = typeof renderStatsTopAverages !== 'undefined'
+      ? renderStatsTopAverages(data.days)
+      : '';
+    document.getElementById('stats-container').innerHTML = topAveragesHtml + statsHtml;
     
     // Set up comparison selectors
     document.querySelectorAll('.month-comparison-select').forEach(select => {

--- a/styles.css
+++ b/styles.css
@@ -15,12 +15,12 @@
   --color-sleep: #a78bfa;
   --color-nap: #c4b5fd;
   --color-bed: #60a5fa;
-  --color-alarm: #f87171;
+  --color-alarm: #c2410c;
   --color-sick: #ec4899;
   --color-bath: #fbbf24;
   --color-up: #34d399;
   --color-sunrise: #f59e0b;
-  --color-warning: #f87171;
+  --color-warning: #c2410c;
   --color-default-event: #e5e7eb;
   --color-hover-blue: #93c5fd;
   
@@ -32,6 +32,56 @@
   --weekend-border: rgba(96, 165, 250, 0.4);
   --warning-bg: rgba(251, 191, 36, 0.1);
   --warning-border: rgba(251, 191, 36, 0.4);
+  --tick-line: rgba(255, 255, 255, 0.2);
+  --tick-label: rgba(255, 255, 255, 0.5);
+}
+
+/* Day mode (after sunrise, before sunset) */
+[data-theme="day"] {
+  --bg: #e2e8f0;
+  --panel: #f8fafc;
+  --bar: #cbd5e1;
+  --grid: rgba(0, 0, 0, 0.06);
+  --text: #0f172a;
+  --hover-bg: rgba(0, 0, 0, 0.06);
+  --tooltip-bg: rgba(15, 23, 42, 0.92);
+  --previous-day-overlay: rgba(0, 0, 0, 0.12);
+  --weekend-bg: rgba(96, 165, 250, 0.12);
+  --weekend-border: rgba(96, 165, 250, 0.35);
+  --warning-bg: rgba(251, 191, 36, 0.15);
+  --warning-border: rgba(251, 191, 36, 0.45);
+  /* Darker palette for keyword/legend readability on light background */
+  --color-sleep: #5b21b6;
+  --color-nap: #6d28d9;
+  --color-bed: #1d4ed8;
+  --color-alarm: #9a3412;
+  --color-sick: #9d174d;
+  --color-bath: #b45309;
+  --color-up: #047857;
+  --color-sunrise: #b45309;
+  --color-warning: #9a3412;
+  --color-default-event: #475569;
+  --color-hover-blue: #2563eb;
+  --tick-line: rgba(0, 0, 0, 0.22);
+  --tick-label: rgba(15, 23, 42, 0.65);
+}
+
+/* Day mode: darker flag square colours so labels/contrast are easier to read */
+[data-theme="day"] .legend-square.flag-none,
+[data-theme="day"] .calendar-square.flag-none {
+  background: #166534;
+}
+[data-theme="day"] .legend-square.flag-one,
+[data-theme="day"] .calendar-square.flag-one {
+  background: #a16207;
+}
+[data-theme="day"] .legend-square.flag-two,
+[data-theme="day"] .calendar-square.flag-two {
+  background: #854d0e;
+}
+[data-theme="day"] .legend-square.flag-three-plus,
+[data-theme="day"] .calendar-square.flag-three-plus {
+  background: #7f1d1d;
 }
 
 body{
@@ -39,6 +89,7 @@ body{
   color: var(--text);
   font-family: system-ui, sans-serif;
   padding: 20px;
+  transition: background-color 0.35s ease, color 0.35s ease;
 }
 
 .nav-link{
@@ -77,6 +128,32 @@ body{
   align-items: center;
 }
 
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.nav-daynight {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+  opacity: 0.8;
+  transition: opacity 0.2s;
+  cursor: pointer;
+}
+
+.nav-daynight:hover {
+  opacity: 1;
+}
+
+.nav-daynight-icon {
+  width: 20px;
+  height: 20px;
+}
+
 .nav-github-link {
   display: flex;
   align-items: center;
@@ -84,7 +161,6 @@ body{
   color: var(--text);
   opacity: 0.7;
   transition: opacity 0.2s;
-  margin-left: auto;
 }
 
 .nav-github-link:hover {
@@ -242,49 +318,110 @@ body{
   margin-bottom: 20px;
 }
 
+.dashboard-7d-row {
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+  margin-bottom: 20px;
+}
+
+.dashboard-7d-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.dashboard-7d-graph-container {
+  background: var(--panel);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: auto;
+  min-height: 280px;
+}
+
 .dashboard-top-col {
   flex: 1;
   min-width: 0;
 }
 
 .dashboard-top-col--tonight {
-  flex: 0 1 auto;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .dashboard-top-col--calendar {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-width: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: flex-start;
 }
 
 .dashboard-top-col--calendar .calendar-heatmap--inline {
   margin: 0;
   width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.dashboard-top-col--calendar .calendar-heatmap.calendar-heatmap--inline {
+  padding-bottom: 0;
 }
 
 .dashboard-top-col--calendar .calendar-current-month-row {
   width: 100%;
   margin-bottom: 0;
+  padding-bottom: 0;
+  display: flex;
+  justify-content: center;
 }
 
 .dashboard-top-col--calendar .calendar-month-block--large {
-  width: 100%;
+  width: fit-content;
   box-sizing: border-box;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-month-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-month-name {
+  text-align: center;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-month-flag-counter {
+  display: flex;
+  justify-content: center;
 }
 
 .dashboard-top-col--calendar .calendar-month-block--large .calendar-weekday-cells--in-block {
   display: flex;
   width: 100%;
+  gap: 6px;
+  justify-content: center;
 }
 
 .dashboard-top-col--calendar .calendar-month-block--large .calendar-weekday-label {
-  flex: 1;
-  min-width: 0;
-  width: auto;
-  max-width: none;
+  flex: 0 0 28px;
+  width: 28px;
+  min-width: 28px;
+  box-sizing: border-box;
+  text-align: center;
 }
 
 .dashboard-top-col--calendar .calendar-month-block--large .calendar-month-row {
   width: 100%;
+  margin-bottom: 8px;
+}
+
+.dashboard-top-col--calendar .calendar-month-block--large .calendar-month-row:last-child {
+  margin-bottom: 0;
 }
 
 .dashboard-top-col--calendar .calendar-month-block--large .calendar-days-row {
@@ -292,13 +429,16 @@ body{
   flex: 1;
   width: 100%;
   min-width: 0;
+  justify-content: center;
 }
 
 .dashboard-top-col--calendar .calendar-month-block--large .calendar-square {
-  flex: 1;
-  min-width: 0;
-  width: auto;
-  max-width: none;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  min-height: 28px;
+  border-radius: 50%;
 }
 
 .calendar-heatmap--inline {
@@ -311,24 +451,29 @@ body{
   margin: 0 0 4px 0;
   color: var(--text);
   opacity: 0.95;
+  text-align: center;
 }
 
 .dashboard-projection-copy {
   font-size: 0.8rem;
   margin: 0 0 14px 0;
   opacity: 0.75;
+  text-align: center;
 }
 
 .dashboard-projection-grid {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  align-items: center;
 }
 
 .dashboard-projection-item {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  align-items: center;
+  width: 100%;
 }
 
 .dashboard-projection-item--wake {
@@ -338,6 +483,7 @@ body{
 .dashboard-projection-label {
   font-size: 0.85rem;
   opacity: 0.9;
+  text-align: center;
 }
 
 .proj-keyword.proj-sleep {
@@ -346,8 +492,42 @@ body{
 }
 
 .proj-keyword.proj-wake {
-  color: var(--color-sunrise);
+  color: var(--color-up);
   font-weight: 600;
+}
+
+.dashboard-projection-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: 6px 10px;
+  min-width: 0;
+}
+
+.dashboard-projection-sep {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text);
+  opacity: 0.5;
+  user-select: none;
+}
+
+.dashboard-projection-target {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  min-width: 7ch;
+  text-align: center;
+}
+
+.dashboard-projection-bounds {
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  opacity: 0.6;
 }
 
 .dashboard-projection-range {
@@ -355,6 +535,13 @@ body{
   font-weight: 600;
   letter-spacing: 0.02em;
   color: var(--text);
+}
+
+.dashboard-projection-duration {
+  font-size: 0.85rem;
+  margin: 10px 0 0 0;
+  opacity: 0.8;
+  text-align: center;
 }
 
 .dashboard-averages-panel{
@@ -495,10 +682,30 @@ body{
   border-radius: 14px;
   padding: 14px 16px 18px;
   margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.week-summary-spacer{
+  width: 60px;
+  min-width: 60px;
+  flex-shrink: 0;
+}
+
+.week-summary .day-stats{
+  width: 220px;
+  min-width: 220px;
+  flex-shrink: 0;
 }
 
 .week-summary-bar{
-  margin-bottom: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.week-summary-bar .bar{
+  margin-bottom: 0;
 }
 
 .week-summary-bar .bar{
@@ -527,8 +734,24 @@ body{
 
 .day-date{
   font-weight: 700;
+  width: 60px;
   min-width: 60px;
   flex-shrink: 0;
+}
+
+/* Stats column: fixed width so labels/values align across all days; graph starts at same place */
+.day-content .day-stats{
+  width: 220px;
+  min-width: 220px;
+  flex-shrink: 0;
+}
+
+.day-bar-container{
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .deviation-warnings{
@@ -548,13 +771,6 @@ body{
   border-radius: 6px;
   border-left: 2px solid var(--warning-border);
   width: fit-content;
-}
-
-.day-bar-container{
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .day-stats{
@@ -803,7 +1019,7 @@ body{
   transform: translate(-50%, -50%);
   width: 0.5px;
   height: calc(var(--bar-h) + 2px);
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--tick-line);
   left: calc((var(--m) / var(--minutes)) * 100%);
   z-index: 0;
   opacity: 0;
@@ -820,7 +1036,7 @@ body{
   left: 50%;
   transform: translateX(-50%);
   font-size: 9px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--tick-label);
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
@@ -847,6 +1063,30 @@ h1 {
   min-width: 800px;
   overflow-x: auto;
   overflow-y: visible;
+}
+
+.graph-container.chart-section {
+  margin-top: 40px;
+}
+
+.graph-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.graph-page-header h1 {
+  margin: 0;
+}
+
+.chart-error {
+  color: var(--color-warning);
+  padding: 10px;
+  background: rgba(194, 65, 12, 0.1);
+  margin: 10px 0;
 }
 
 svg {
@@ -1348,7 +1588,7 @@ svg {
 }
 
 .stat-diff.red {
-  color: var(--color-alarm); /* Use red color from CSS */
+  color: var(--color-alarm);
 }
 
 .stat-percentage {


### PR DESCRIPTION
# Update Summary

## 1. Replace `sleep.css` with `styles.css` and add day/night theme

All pages now use a single `styles.css`; `sleep.css` is removed.
New styles add a time-based day/night theme (`[data-theme="day"]` / `[data-theme="night"]`) with separate CSS variable sets, plus styles for dashboard projection, 7-day graphs, calendar heatmap, and nav.

## 2. Add dashboard 7-day mini-graphs

Dashboard shows two small charts for the last 7 days:

* Time-series (bed / fell asleep / get up)
* Sleep-duration bar chart

Both are drawn as SVG in JS.

## 3. Add “Tonight” projection and current-month heatmap to dashboard

Dashboard top section shows:

* “Recommended tonight” window (recent 3-day average ±30 min)
* Current month’s sleep-quality calendar heatmap (flag counts per day)