### PR TITLE
Wake time, sun icon, dashboard graph

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,12 +38,46 @@
         <span class="about-page-desc">Monthly sleep statistics.</span>
       </li>
     </ul>
+
+    <h2 class="about-section-title" id="remaining-wake-time">Remaining Wake Time</h2>
+    <p class="about-section-intro">Shows how much time is left in your day before your recommended sleep time. Phases are based on the <strong>percent of wake time remaining</strong> (these thresholds may become configurable in a future update).</p>
+    <p class="about-section-intro">The day is divided into three simple phases:</p>
+    <ul class="about-phase-list">
+      <li class="about-phase-item">
+        <span class="about-phase-icon" aria-hidden="true">☀️</span>
+        <div class="about-phase-body">
+          <span class="about-phase-name">1. “Open time” (plenty of runway)</span>
+          <span class="about-phase-range">Range: ~100% → 40% remaining</span>
+          <span class="about-phase-note">(i.e., you’re in the first ~60% of your day)</span>
+          <span class="about-phase-feeling">Feeling: steady, normal, no urgency</span>
+        </div>
+      </li>
+      <li class="about-phase-item">
+        <span class="about-phase-icon" aria-hidden="true">🌇</span>
+        <div class="about-phase-body">
+          <span class="about-phase-name">2. “Winding down window”</span>
+          <span class="about-phase-range">Range: ~40% → 15% remaining</span>
+          <span class="about-phase-note">This is the “you’re past the midpoint” zone</span>
+          <span class="about-phase-feeling">Feeling: awareness, gentle shift</span>
+        </div>
+      </li>
+      <li class="about-phase-item">
+        <span class="about-phase-icon" aria-hidden="true">🛏️</span>
+        <div class="about-phase-body">
+          <span class="about-phase-name">3. “Pre-sleep phase”</span>
+          <span class="about-phase-range">Range: ~15% → 0% remaining</span>
+          <span class="about-phase-feeling">Time to start easing out and prepare for rest</span>
+        </div>
+      </li>
+    </ul>
+    <p class="about-section-note">This is meant to gently guide your pace, not rush you.</p>
   </div>
 
   <script src="sleep-utils.js"></script>
   <script>
     document.getElementById('nav-container').innerHTML = renderNavBar('about');
     initDayNightTheme();
+    initRemainingWakeNav();
   </script>
 </body>
 </html>

--- a/daily.html
+++ b/daily.html
@@ -17,9 +17,9 @@
   <script src="sleep-utils.js"></script>
   <script src="daily.js"></script>
   <script>
-    // Add navigation bar
     document.getElementById('nav-container').innerHTML = renderNavBar('timeline');
     initDayNightTheme();
+    initRemainingWakeNav();
   </script>
 </body>
 </html>

--- a/daily.js
+++ b/daily.js
@@ -711,14 +711,47 @@ function renderCalendarHeatmapFullHistory(year, flagMap, latestDataDate) {
   `;
 }
 
-// Recommended sleep/wake window: recent average ± 30 minutes (same recent-days logic as dashboard).
+// Recommended sleep/wake window: sleep band ±30 min; wake band ±15 min (wake consistency is more important).
 const PROJECTION_BAND_MINUTES = 30;
+const WAKE_PROJECTION_BAND_MINUTES = 15;
+
+// Phase thresholds (percent of wake time remaining): open >= 40%, winding 15–40%, pre-sleep < 15%.
+function getRemainingWakePhase(remainingMins, sleepTargetMins) {
+  if (sleepTargetMins <= 0) return 'open';
+  const percentRemaining = Math.min(100, (remainingMins / sleepTargetMins) * 100);
+  if (percentRemaining >= 40) return 'open';
+  if (percentRemaining >= 15) return 'winding';
+  return 'presleep';
+}
+
+function getRemainingWakeIcon(phase) {
+  switch (phase) {
+    case 'open': return '☀️';
+    case 'winding': return '🌇';
+    case 'presleep': return '🛏️';
+    default: return '☀️';
+  }
+}
+
+/** Returns { phase, icon, timeLabel } for remaining wake time (used by dashboard nav). */
+function getRemainingWakeDisplay(recentAverages) {
+  const sleepTarget = recentAverages.avgBedtime;
+  const now = new Date();
+  const nowMins = now.getHours() * 60 + now.getMinutes();
+  const remainingMins = sleepTarget >= nowMins
+    ? sleepTarget - nowMins
+    : 1440 - nowMins + sleepTarget;
+  const phase = getRemainingWakePhase(remainingMins, sleepTarget);
+  const icon = getRemainingWakeIcon(phase);
+  const timeLabel = formatDuration(Math.round(remainingMins));
+  return { phase, icon, timeLabel };
+}
 
 function renderDashboardProjection(recentAverages) {
   const sleepByLow = Math.max(0, recentAverages.avgBedtime - PROJECTION_BAND_MINUTES);
   const sleepByHigh = Math.min(1440, recentAverages.avgBedtime + PROJECTION_BAND_MINUTES);
-  const wakeByLow = Math.max(0, recentAverages.avgSleepEnd - PROJECTION_BAND_MINUTES);
-  const wakeByHigh = Math.min(1440, recentAverages.avgSleepEnd + PROJECTION_BAND_MINUTES);
+  const wakeByLow = Math.max(0, recentAverages.avgSleepEnd - WAKE_PROJECTION_BAND_MINUTES);
+  const wakeByHigh = Math.min(1440, recentAverages.avgSleepEnd + WAKE_PROJECTION_BAND_MINUTES);
 
   const sleepTarget = recentAverages.avgBedtime;
   const wakeTarget = recentAverages.avgSleepEnd;
@@ -726,18 +759,9 @@ function renderDashboardProjection(recentAverages) {
     ? wakeTarget - sleepTarget
     : 1440 - sleepTarget + wakeTarget;
 
-  // Time until recommended bedtime (from page load): minutes from midnight
-  const now = new Date();
-  const nowMins = now.getHours() * 60 + now.getMinutes();
-  const remainingMins = sleepTarget >= nowMins
-    ? sleepTarget - nowMins
-    : 1440 - nowMins + sleepTarget;
-  const remainingLabel = `${formatDuration(Math.round(remainingMins))} until recommended bedtime`;
-
   return `
     <div class="dashboard-projection dashboard-projection--no-box">
       <h2 class="dashboard-projection-title">Tonight</h2>
-      <p class="dashboard-projection-copy">(recent three-day ± ${PROJECTION_BAND_MINUTES} min)</p>
       <div class="dashboard-projection-grid">
         <div class="dashboard-projection-item">
           <span class="dashboard-projection-label"><span class="proj-keyword proj-sleep">🌙 Sleep</span></span>
@@ -761,7 +785,6 @@ function renderDashboardProjection(recentAverages) {
         </div>
       </div>
       <p class="dashboard-projection-duration">(~${formatDuration(recommendedDurationMins)} sleep)</p>
-      <p class="dashboard-projection-remaining">${remainingLabel}</p>
     </div>
   `;
 }
@@ -772,7 +795,7 @@ function renderDashboardContent(days) {
   if (!days || days.length === 0) {
     return '<p>No sleep data yet.</p>';
   }
-  const recentDays = days.slice(0, Math.min(3, days.length));
+  const recentDays = days.slice(0, Math.min(7, days.length));
   const recentAverages = calculateAverages(recentDays);
 
   const flagMap = buildFlagCountMap(days);

--- a/dashboard.js
+++ b/dashboard.js
@@ -86,49 +86,6 @@ function get7DayAxisLabel(point, index, total) {
   return days[d.getDay()];
 }
 
-/** Show day-panel popup with daily values (same as graph.js). Position near clientX/clientY. */
-function showDashboardDayPanel(point, clientX, clientY) {
-  const dayPanel = document.getElementById('day-panel');
-  if (!dayPanel) return;
-  const sleepDuration = formatDuration(point.sleepDurationMinutes);
-  const mainSleep = formatDuration(point.mainSleepMinutes);
-  const napText = point.napMinutes > 0 ? ` (${mainSleep} + ${formatDuration(point.napMinutes)} nap)` : '';
-  dayPanel.innerHTML = `
-    <div class="day-panel-header">${point.dateString}</div>
-    <div class="day-panel-row">
-      <span class="day-panel-label bedtime">bed:</span>
-      <span class="day-panel-value">${point.bedTimeString}</span>
-    </div>
-    <div class="day-panel-row">
-      <span class="day-panel-label sleep-start">sleep:</span>
-      <span class="day-panel-value">${point.sleepStartString}</span>
-    </div>
-    <div class="day-panel-row">
-      <span class="day-panel-label getup">get up:</span>
-      <span class="day-panel-value">${point.getUpString}</span>
-    </div>
-    <div class="day-panel-row">
-      <span class="day-panel-label">sleep duration:</span>
-      <span class="day-panel-value">${sleepDuration}${napText}</span>
-    </div>
-  `;
-  const panelWidth = 200;
-  const panelHeight = 140;
-  let left = clientX + 12;
-  let top = clientY - 10;
-  if (left + panelWidth > window.innerWidth - 20) left = clientX - panelWidth - 12;
-  if (top < 20) top = 20;
-  if (top + panelHeight > window.innerHeight - 20) top = window.innerHeight - panelHeight - 20;
-  dayPanel.style.left = left + 'px';
-  dayPanel.style.top = top + 'px';
-  dayPanel.classList.add('visible');
-}
-
-function hideDashboardDayPanel() {
-  const dayPanel = document.getElementById('day-panel');
-  if (dayPanel) dayPanel.classList.remove('visible');
-}
-
 function buildPoints(days) {
   return days.map(day => {
     const rawBed = timeToMinutes(day.bed);
@@ -341,15 +298,15 @@ function render7DayTimeGraph(container, points) {
       const rect = container.getBoundingClientRect();
       const clientX = rect.left + margin.left + x;
       const clientY = rect.top + margin.top + graphHeight / 2;
-      showDashboardDayPanel(point, clientX, clientY);
+      showDayPanel(point, clientX, clientY);
       setTimeout(() => {
+        const dayPanel = document.getElementById('day-panel');
         const close = (e2) => {
-          if (!dayPanel.contains(e2.target) && !container.contains(e2.target)) {
-            hideDashboardDayPanel();
+          if (dayPanel && !dayPanel.contains(e2.target) && !container.contains(e2.target)) {
+            hideDayPanel();
             document.removeEventListener('click', close);
           }
         };
-        const dayPanel = document.getElementById('day-panel');
         document.addEventListener('click', close);
       }, 0);
     });
@@ -483,12 +440,12 @@ function render7DayDurationChart(container, points) {
     mainRect.addEventListener('mouseleave', () => { if (tooltip) tooltip.classList.remove('visible'); });
     mainRect.addEventListener('click', (e) => {
       const rect = container.getBoundingClientRect();
-      showDashboardDayPanel(point, e.clientX, e.clientY);
+      showDayPanel(point, e.clientX, e.clientY);
       setTimeout(() => {
         const dayPanel = document.getElementById('day-panel');
         const close = (e2) => {
           if (dayPanel && !dayPanel.contains(e2.target) && !container.contains(e2.target)) {
-            hideDashboardDayPanel();
+            hideDayPanel();
             document.removeEventListener('click', close);
           }
         };
@@ -519,12 +476,12 @@ function render7DayDurationChart(container, points) {
       });
       napRect.addEventListener('mouseleave', () => { if (tooltip) tooltip.classList.remove('visible'); });
       napRect.addEventListener('click', (e) => {
-        showDashboardDayPanel(point, e.clientX, e.clientY);
+        showDayPanel(point, e.clientX, e.clientY);
         setTimeout(() => {
           const dayPanel = document.getElementById('day-panel');
           const close = (e2) => {
             if (dayPanel && !dayPanel.contains(e2.target) && !container.contains(e2.target)) {
-              hideDashboardDayPanel();
+              hideDayPanel();
               document.removeEventListener('click', close);
             }
           };
@@ -574,6 +531,12 @@ if (dashboardContainer) {
       if (typeof holidays !== 'undefined') holidays = holidaysData;
       dashboardContainer.innerHTML = renderDashboardContent(sleepData.days);
       renderDashboard7DayGraphs(sleepData.days);
+
+      const recentDays = sleepData.days.slice(0, Math.min(7, sleepData.days.length));
+      if (recentDays.length > 0 && typeof getRemainingWakeDisplay === 'function' && typeof updateRemainingWakeNav === 'function') {
+        const recentAverages = calculateAverages(recentDays);
+        updateRemainingWakeNav(getRemainingWakeDisplay(recentAverages));
+      }
     })
     .catch(error => {
       console.error('Error loading dashboard data:', error);

--- a/graph.html
+++ b/graph.html
@@ -63,6 +63,7 @@
   <script>
     document.getElementById('nav-container').innerHTML = renderNavBar('graph');
     initDayNightTheme();
+    initRemainingWakeNav();
   </script>
 </body>
 </html>

--- a/graph.js
+++ b/graph.js
@@ -425,7 +425,6 @@ Promise.all([
 
     // Draw data points
     const tooltip = document.getElementById('tooltip');
-    const dayPanel = document.getElementById('day-panel');
     
     // Create vertical hover line indicator
     const hoverLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
@@ -538,65 +537,16 @@ Promise.all([
         hoverLine.setAttribute('y2', graphHeight);
         hoverLine.style.display = 'block';
         
-        // Get SVG position relative to viewport
+        // Get SVG position relative to viewport and show shared day panel
         const svgRect = svg.getBoundingClientRect();
         const baseX = svgRect.left + margin.left + x;
         const baseY = svgRect.top + margin.top;
-        
-        // Build consolidated day panel content
-        const sleepDuration = formatDuration(point.sleepDurationMinutes);
-        const mainSleep = formatDuration(point.mainSleepMinutes);
-        const napText = point.napMinutes > 0 ? ` (${mainSleep} + ${formatDuration(point.napMinutes)} nap)` : '';
-        
-        dayPanel.innerHTML = `
-          <div class="day-panel-header">${point.dateString}</div>
-          <div class="day-panel-row">
-            <span class="day-panel-label bedtime">bed:</span>
-            <span class="day-panel-value">${point.bedTimeString}</span>
-          </div>
-          <div class="day-panel-row">
-            <span class="day-panel-label sleep-start">sleep:</span>
-            <span class="day-panel-value">${point.sleepStartString}</span>
-          </div>
-          <div class="day-panel-row">
-            <span class="day-panel-label getup">get up:</span>
-            <span class="day-panel-value">${point.getUpString}</span>
-          </div>
-          <div class="day-panel-row">
-            <span class="day-panel-label">sleep duration:</span>
-            <span class="day-panel-value">${sleepDuration}${napText}</span>
-          </div>
-        `;
-        
-        // Position panel to the right of the hover line, or left if too close to edge
-        const panelWidth = 200; // Approximate width
-        const panelHeight = 120; // Approximate height
-        let panelX = baseX + 15;
-        let panelY = baseY + graphHeight / 2 - panelHeight / 2;
-        
-        // Adjust if too close to right edge
-        if (panelX + panelWidth > window.innerWidth - 20) {
-          panelX = baseX - panelWidth - 15;
-        }
-        
-        // Adjust if too close to top or bottom
-        if (panelY < 20) {
-          panelY = 20;
-        } else if (panelY + panelHeight > window.innerHeight - 20) {
-          panelY = window.innerHeight - panelHeight - 20;
-        }
-        
-        dayPanel.style.left = panelX + 'px';
-        dayPanel.style.top = panelY + 'px';
-        dayPanel.classList.add('visible');
+        showDayPanel(point, baseX, baseY + graphHeight / 2);
       });
       
       hoverRect.addEventListener('mouseleave', () => {
-        // Hide vertical line
         hoverLine.style.display = 'none';
-        
-        // Hide day panel
-        dayPanel.classList.remove('visible');
+        hideDayPanel();
       });
       
       // Add at the end so it's on top for interaction but transparent

--- a/quality.html
+++ b/quality.html
@@ -18,6 +18,7 @@
   <script>
     document.getElementById('nav-container').innerHTML = renderNavBar('quality');
     initDayNightTheme();
+    initRemainingWakeNav();
   </script>
 </body>
 </html>

--- a/sleep-data.json
+++ b/sleep-data.json
@@ -1,6 +1,16 @@
 {
   "days": [
     {
+      "date": "3/18",
+      "bed": "22:22",
+      "sleepStart": "22:53",
+      "sleepEnd": "7:11",
+      "bathroom": ["3:30"],
+      "alarm": ["7:10"],
+      "sick": [],
+      "nap": null
+    },
+    {
       "date": "3/17",
       "bed": "23:05",
       "sleepStart": "23:40",

--- a/sleep-utils.js
+++ b/sleep-utils.js
@@ -308,8 +308,7 @@ function applyDayNightTheme() {
   return theme;
 }
 
-// Sun icon: filled circle + rays (visible when filled)
-const SUN_ICON = '<svg class="nav-daynight-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303l-1.591 1.59a.75.75 0 001.06-1.061l1.591-1.59a.75.75 0 00-1.06-1.06zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591a.75.75 0 001.061-1.06z"/></svg>';
+const SUN_ICON = '<svg xmlns="http://www.w3.org/2000/svg" class="nav-daynight-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM5.106 18.894a.75.75 0 001.06 1.06l1.591-1.59a.75.75 0 10-1.06-1.061l-1.591 1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591a.75.75 0 001.061-1.06z"/></svg>';
 const MOON_ICON = '<svg class="nav-daynight-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/></svg>';
 
 function getDayNightTitle(theme, isOverride) {
@@ -383,7 +382,113 @@ function renderNavBar(currentPage) {
   const navRight = `<div class="nav-right">${dayNightIcon}${aboutLink}${githubLink}</div>`;
 
   const appName = '<div class="nav-app-block"><span class="nav-app-name">Restore</span><span class="nav-app-subtitle">Sleep Tracker</span></div>';
-  const headerRow = `<div class="nav-header">${appName}${navRight}</div>`;
+  const headerRow = `<div class="nav-header nav-header--remaining-wake">${appName}<div class="nav-remaining-wake" id="nav-remaining-wake"></div>${navRight}</div>`;
   const tabsRow = `<div class="nav-tabs-row"><div class="nav-tabs">${navItems}</div></div>`;
-  return `<div class="nav-wrapper">${headerRow}${tabsRow}</div>`;
+  return `<div class="nav-wrapper nav-wrapper--remaining-wake">${headerRow}${tabsRow}</div>`;
+}
+
+// Phase thresholds (percent of wake time remaining): open >= 40%, winding 15–40%, pre-sleep < 15%.
+function getRemainingWakePhase(remainingMins, sleepTargetMins) {
+  if (sleepTargetMins <= 0) return 'open';
+  const percentRemaining = Math.min(100, (remainingMins / sleepTargetMins) * 100);
+  if (percentRemaining >= 40) return 'open';
+  if (percentRemaining >= 15) return 'winding';
+  return 'presleep';
+}
+
+function getRemainingWakeIcon(phase) {
+  switch (phase) {
+    case 'open': return '☀️';
+    case 'winding': return '🌇';
+    case 'presleep': return '🛏️';
+    default: return '☀️';
+  }
+}
+
+/** Returns { phase, icon, timeLabel } from raw days (used when daily.js not loaded).
+ * Uses same logic as dashboard: recent 7 days, average sleep start (fell asleep) with normalize/denormalize. */
+function getRemainingWakeDisplayFromDays(days) {
+  if (!days || days.length === 0) return null;
+  const recent = days.slice(0, Math.min(7, days.length));
+  const sleepStartSum = recent.reduce((s, d) => s + normalizeTimeForAveraging(timeToMinutes(d.sleepStart)), 0);
+  const avgSleepTarget = denormalizeTimeForAveraging(Math.round(sleepStartSum / recent.length));
+  const now = new Date();
+  const nowMins = now.getHours() * 60 + now.getMinutes();
+  const remainingMins = avgSleepTarget >= nowMins ? avgSleepTarget - nowMins : 1440 - nowMins + avgSleepTarget;
+  const phase = getRemainingWakePhase(remainingMins, avgSleepTarget);
+  const icon = getRemainingWakeIcon(phase);
+  const timeLabel = formatDuration(Math.round(remainingMins));
+  return { phase, icon, timeLabel };
+}
+
+/** Injects remaining wake into nav and sets phase class on wrapper. Call with { phase, icon, timeLabel }. */
+function updateRemainingWakeNav(display) {
+  if (!display) return;
+  const slot = document.getElementById('nav-remaining-wake');
+  const wrapper = document.querySelector('.nav-wrapper');
+  if (slot) {
+    slot.innerHTML = `<a href="about.html#remaining-wake-time" class="nav-remaining-wake-link" title="Remaining wake time" aria-label="Remaining wake time"><span class="nav-remaining-wake-icon" aria-hidden="true">${display.icon}</span><span class="nav-remaining-wake-time">${display.timeLabel}</span></a>`;
+  }
+  if (wrapper) {
+    wrapper.classList.remove('nav-wrapper--phase-open', 'nav-wrapper--phase-winding', 'nav-wrapper--phase-presleep');
+    wrapper.classList.add('nav-wrapper--phase-' + display.phase);
+  }
+}
+
+/** Fetches sleep data and fills remaining wake in nav. Call on every page so header is consistent. */
+function initRemainingWakeNav() {
+  fetch('sleep-data.json')
+    .then(r => r.json())
+    .then(data => {
+      const display = getRemainingWakeDisplayFromDays(data.days);
+      updateRemainingWakeNav(display);
+    })
+    .catch(() => {});
+}
+
+/**
+ * Show the shared day-panel popup with bed, sleep, get up, and sleep duration.
+ * point: { dateString, bedTimeString, sleepStartString, getUpString, sleepDurationMinutes, mainSleepMinutes?, napMinutes? }
+ * Position is derived from clientX/clientY, flipping to stay on screen.
+ */
+function showDayPanel(point, clientX, clientY) {
+  const dayPanel = document.getElementById('day-panel');
+  if (!dayPanel) return;
+  const sleepDuration = formatDuration(point.sleepDurationMinutes);
+  const mainSleep = formatDuration(point.mainSleepMinutes != null ? point.mainSleepMinutes : point.sleepDurationMinutes);
+  const napText = (point.napMinutes != null && point.napMinutes > 0) ? ` (${mainSleep} + ${formatDuration(point.napMinutes)} nap)` : '';
+  dayPanel.innerHTML = `
+    <div class="day-panel-header">${point.dateString}</div>
+    <div class="day-panel-row">
+      <span class="day-panel-label bedtime">bed:</span>
+      <span class="day-panel-value">${point.bedTimeString}</span>
+    </div>
+    <div class="day-panel-row">
+      <span class="day-panel-label sleep-start">sleep:</span>
+      <span class="day-panel-value">${point.sleepStartString}</span>
+    </div>
+    <div class="day-panel-row">
+      <span class="day-panel-label getup">get up:</span>
+      <span class="day-panel-value">${point.getUpString}</span>
+    </div>
+    <div class="day-panel-row">
+      <span class="day-panel-label">sleep duration:</span>
+      <span class="day-panel-value">${sleepDuration}${napText}</span>
+    </div>
+  `;
+  const panelWidth = 200;
+  const panelHeight = 140;
+  let left = clientX + 12;
+  let top = clientY - 10;
+  if (left + panelWidth > window.innerWidth - 20) left = clientX - panelWidth - 12;
+  if (top < 20) top = 20;
+  if (top + panelHeight > window.innerHeight - 20) top = window.innerHeight - panelHeight - 20;
+  dayPanel.style.left = left + 'px';
+  dayPanel.style.top = top + 'px';
+  dayPanel.classList.add('visible');
+}
+
+function hideDayPanel() {
+  const dayPanel = document.getElementById('day-panel');
+  if (dayPanel) dayPanel.classList.remove('visible');
 }

--- a/stats.html
+++ b/stats.html
@@ -17,9 +17,9 @@
   <script src="daily.js"></script>
   <script src="stats.js"></script>
   <script>
-    // Add navigation bar
     document.getElementById('nav-container').innerHTML = renderNavBar('stats');
     initDayNightTheme();
+    initRemainingWakeNav();
   </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -372,6 +372,64 @@ body{
   gap: 20px;
 }
 
+/* Remaining wake time in nav header (all pages; no extra (i) — link uses title tooltip) */
+.nav-header--remaining-wake {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  border: none;
+}
+
+.nav-header--remaining-wake .nav-app-block {
+  justify-self: start;
+}
+
+.nav-header--remaining-wake .nav-remaining-wake {
+  justify-self: center;
+}
+
+.nav-header--remaining-wake .nav-right {
+  justify-self: end;
+}
+
+.nav-remaining-wake-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1.125rem;
+  transition: opacity 0.2s;
+}
+
+.nav-remaining-wake-link:hover {
+  opacity: 0.9;
+}
+
+.nav-remaining-wake-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.nav-remaining-wake-time {
+  letter-spacing: 0.02em;
+}
+
+/* Phase-colored header (dashboard only) */
+.nav-wrapper--phase-open .nav-header {
+  background: rgba(134, 239, 172, 0.18);
+}
+
+.nav-wrapper--phase-winding .nav-header {
+  background: rgba(253, 230, 138, 0.22);
+}
+
+.nav-wrapper--phase-presleep .nav-header {
+  background: rgba(196, 181, 253, 0.2);
+}
+
 .dashboard-projection {
   background: var(--panel);
   border-radius: 14px;
@@ -2185,5 +2243,78 @@ svg {
   color: var(--text);
   opacity: 0.85;
   font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+/* About page — Remaining Wake Time section */
+.about-section-title {
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.about-section-intro {
+  margin: 0 0 0.5rem;
+  color: var(--text);
+  opacity: 0.9;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+.about-phase-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+}
+
+.about-phase-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 0;
+  color: var(--text);
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+.about-phase-icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.about-phase-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.about-phase-name {
+  font-weight: 600;
+}
+
+.about-phase-range {
+  opacity: 0.9;
+  font-size: 0.9em;
+}
+
+.about-phase-note {
+  opacity: 0.8;
+  font-size: 0.9em;
+  font-style: italic;
+}
+
+.about-phase-feeling {
+  opacity: 0.85;
+  font-size: 0.9em;
+}
+
+.about-section-note {
+  margin: 1rem 0 0;
+  color: var(--text);
+  opacity: 0.8;
+  font-size: 0.875rem;
+  font-style: italic;
   line-height: 1.45;
 }


### PR DESCRIPTION
## Recommended wake time

- Updated calculation to use 7-day avg, like in `daily.js`
- Get up time band tighter (+/- 15 min)
- Uses main banner instead of "Tonight" section
- Added documentation in `about.html`

## Dashboard graphs

- Now show daily detail panel like in `graph.html`

## Light/dark mode

- Fixed sun icon SVG