### PR TITLE
wake time, new day, mobile, settings, dev build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# Requires GNU Make + Node. On Windows without make, use: npm run new-day  or  .\new-day.cmd
+.PHONY: new-day
+new-day:
+	node scripts/new-day.js

--- a/config.html
+++ b/config.html
@@ -13,6 +13,23 @@
   <div class="container container--config">
     <h1 class="page-title config-page-title">Settings</h1>
 
+    <h2 class="section-title" id="clock">Clock</h2>
+    <p class="section-intro">Choose how times are shown across the app.</p>
+    <div id="config-clock" class="about-theme" role="group" aria-label="Clock format preference">
+      <button type="button" class="about-theme-option" data-clock-format="12h" aria-pressed="false">
+        <span class="about-theme-option-icon" aria-hidden="true">
+          <span class="clock-format-icon-text">AM/PM</span>
+        </span>
+        <span>12-hour</span>
+      </button>
+      <button type="button" class="about-theme-option" data-clock-format="24h" aria-pressed="false">
+        <span class="about-theme-option-icon" aria-hidden="true">
+          <span class="clock-format-icon-text">00:00</span>
+        </span>
+        <span>24-hour</span>
+      </button>
+    </div>
+
     <h2 class="section-title" id="theme">Theme</h2>
     <p class="section-intro">Choose Light / Dark or Auto (time-based: follows time of day).</p>
     <div id="config-theme" class="about-theme" role="group" aria-label="Theme preference">
@@ -38,6 +55,7 @@
   <script>
     document.getElementById('nav-container').innerHTML = renderNavBar('config');
     initDayNightTheme();
+    initClockFormatSelector();
     initConfigThemeSelector();
     document.getElementById('remaining-wake-thresholds-mount').innerHTML =
       getRemainingWakeThresholdsControlHTML('remaining-wake-thresholds');

--- a/daily.js
+++ b/daily.js
@@ -741,7 +741,7 @@ function renderCalendarHeatmapFullHistory(year, flagMap, latestDataDate) {
 const PROJECTION_BAND_MINUTES = 30;
 const WAKE_PROJECTION_BAND_MINUTES = 15;
 
-/** Returns { phase, icon, timeLabel } for remaining wake time (used by dashboard nav). */
+/** Returns { phase, icon, timeLabel, percentRemaining } for remaining wake time (used by dashboard nav). */
 function getRemainingWakeDisplay(recentAverages) {
   const sleepTarget = recentAverages.avgSleepStart;
   const wakeTarget = recentAverages.avgSleepEnd;
@@ -754,7 +754,10 @@ function getRemainingWakeDisplay(recentAverages) {
   const phase = getRemainingWakePhase(remainingMins, totalWakeMins);
   const icon = getRemainingWakeIcon(phase);
   const timeLabel = formatDuration(Math.round(remainingMins));
-  return { phase, icon, timeLabel };
+  const percentRemaining = totalWakeMins > 0
+    ? Math.min(100, Math.max(0, (remainingMins / totalWakeMins) * 100))
+    : 100;
+  return { phase, icon, timeLabel, percentRemaining };
 }
 
 function renderDashboardProjection(recentAverages) {
@@ -828,9 +831,11 @@ function renderDashboardContent(days) {
     <h2 class="dashboard-section-title">Past Week</h2>
     <div class="dashboard-7d-row">
       <div class="dashboard-7d-col">
+        <h3 class="dashboard-7d-subtitle">Wake and sleep times</h3>
         <div class="dashboard-7d-graph-container" id="dashboard-7d-time-graph"></div>
       </div>
       <div class="dashboard-7d-col">
+        <h3 class="dashboard-7d-subtitle">Total sleep time</h3>
         <div class="dashboard-7d-graph-container" id="dashboard-7d-duration-graph"></div>
       </div>
     </div>

--- a/dashboard.js
+++ b/dashboard.js
@@ -46,10 +46,17 @@ function buildPoints(days) {
   });
 }
 
+function getResponsiveDashboardChartWidth(container, pointCount) {
+  const minWidth = 320;
+  const pointDrivenWidth = Math.max(minWidth, pointCount * 36);
+  const containerWidth = container ? Math.floor(container.clientWidth || 0) : 0;
+  return Math.max(pointDrivenWidth, containerWidth);
+}
+
 function render7DayTimeGraph(container, points) {
   if (!points.length) return;
   const margin = { top: 24, right: 24, bottom: 36, left: 48 };
-  const width = Math.max(320, points.length * 36);
+  const width = getResponsiveDashboardChartWidth(container, points.length);
   const height = 280;
   const graphWidth = width - margin.left - margin.right;
   const graphHeight = height - margin.top - margin.bottom;
@@ -251,14 +258,12 @@ function render7DayTimeGraph(container, points) {
 function render7DayDurationChart(container, points) {
   if (!points.length) return;
   const margin = { top: 24, right: 24, bottom: 36, left: 48 };
-  const width = Math.max(320, points.length * 36);
+  const width = getResponsiveDashboardChartWidth(container, points.length);
   const height = 280;
   const graphWidth = width - margin.left - margin.right;
   const graphHeight = height - margin.top - margin.bottom;
-
-  const minDate = points[0].date, maxDate = points[points.length - 1].date;
-  const dateRange = maxDate - minDate || 1;
-  const xScale = (date) => ((date - minDate) / dateRange) * graphWidth;
+  const slotWidth = graphWidth / Math.max(1, points.length);
+  const xScaleByIndex = (index) => slotWidth * (index + 0.5);
 
   // Dynamic Y range: min/max sleep duration in 7 days plus 1 hour on each side
   const allDurations = points.map(p => p.sleepDurationMinutes);
@@ -314,7 +319,7 @@ function render7DayDurationChart(container, points) {
   });
 
   points.forEach((point, index) => {
-    const x = xScale(point.date);
+    const x = xScaleByIndex(index);
     const tickLine = ns('line');
     tickLine.setAttribute('x1', x); tickLine.setAttribute('y1', graphHeight);
     tickLine.setAttribute('x2', x); tickLine.setAttribute('y2', graphHeight + 5);
@@ -344,10 +349,9 @@ function render7DayDurationChart(container, points) {
   });
 
   const tooltip = document.getElementById('tooltip');
-  const dayWidth = graphWidth / Math.max(1, points.length);
-  const barWidth = Math.max(2, dayWidth * 0.8);
-  points.forEach(point => {
-    const x = xScale(point.date);
+  const barWidth = Math.max(2, slotWidth * 0.72);
+  points.forEach((point, index) => {
+    const x = xScaleByIndex(index);
     const mainSleepBarY = sleepYScale(point.mainSleepMinutes);
     const mainRect = ns('rect');
     mainRect.setAttribute('x', x - barWidth / 2);
@@ -430,7 +434,7 @@ function render7DayDurationChart(container, points) {
   );
   let trendD = '';
   points.forEach((p, i) => {
-    const x = xScale(p.date), y = sleepYScale(evaluatePolynomial(sleepReg, i));
+    const x = xScaleByIndex(i), y = sleepYScale(evaluatePolynomial(sleepReg, i));
     trendD += (i ? ' L ' : 'M ') + x + ' ' + y;
   });
   const trendPath = ns('path');
@@ -455,6 +459,20 @@ function renderDashboard7DayGraphs(days) {
   if (durationEl) render7DayDurationChart(durationEl, last7);
 }
 
+let dashboardResizeRenderBound = false;
+function bindDashboardResponsiveRerender(days) {
+  if (dashboardResizeRenderBound) return;
+  dashboardResizeRenderBound = true;
+
+  let resizeTimer = null;
+  window.addEventListener('resize', () => {
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      renderDashboard7DayGraphs(days);
+    }, 120);
+  });
+}
+
 // --- Dashboard bootstrap ---
 const dashboardContainer = document.getElementById('dashboard-container');
 if (dashboardContainer) {
@@ -462,6 +480,7 @@ if (dashboardContainer) {
     .then((sleepData) => {
       dashboardContainer.innerHTML = renderDashboardContent(sleepData.days);
       renderDashboard7DayGraphs(sleepData.days);
+      bindDashboardResponsiveRerender(sleepData.days);
 
       const recentDays = sleepData.days.slice(0, Math.min(7, sleepData.days.length));
       if (recentDays.length > 0 && typeof getRemainingWakeDisplay === 'function' && typeof updateRemainingWakeNav === 'function') {

--- a/new-day.cmd
+++ b/new-day.cmd
@@ -1,0 +1,3 @@
+@echo off
+cd /d "%~dp0"
+node scripts\new-day.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sleep-proj",
+  "private": true,
+  "scripts": {
+    "new-day": "node scripts/new-day.js"
+  }
+}

--- a/scripts/new-day.js
+++ b/scripts/new-day.js
@@ -1,0 +1,80 @@
+/**
+ * Prepends a new day to sleep-data.json (newest-first order).
+ * Run: node scripts/new-day.js   or   make new-day
+ */
+const fs = require('fs');
+const path = require('path');
+
+const dataPath = path.join(__dirname, '..', 'sleep-data.json');
+
+function parseMD(s) {
+  const [m, d] = s.split('/').map(Number);
+  if (!m || !d) throw new Error(`Bad date string: ${s}`);
+  return { m, d };
+}
+
+function formatMD(date) {
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}
+
+function nextDateString(latestMd) {
+  const { m, d } = parseMD(latestMd);
+  const y = new Date().getFullYear();
+  const next = new Date(y, m - 1, d);
+  next.setDate(next.getDate() + 1);
+  return formatMD(next);
+}
+
+function templateFromPrevious(prev) {
+  if (!prev) {
+    return {
+      bed: '22:30',
+      sleepStart: '22:45',
+      sleepEnd: '7:00',
+      bathroom: [],
+      alarm: [],
+      sick: [],
+      nap: null
+    };
+  }
+  return {
+    bed: prev.bed,
+    sleepStart: prev.sleepStart,
+    sleepEnd: prev.sleepEnd,
+    bathroom: [...(prev.bathroom || [])],
+    alarm: [...(prev.alarm || [])],
+    sick: [],
+    nap: null
+  };
+}
+
+function main() {
+  const raw = fs.readFileSync(dataPath, 'utf8');
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data.days)) {
+    console.error('sleep-data.json: expected top-level { days: [...] }');
+    process.exit(1);
+  }
+
+  const days = data.days;
+  let dateStr;
+  if (days.length === 0) {
+    dateStr = formatMD(new Date());
+  } else {
+    dateStr = nextDateString(days[0].date);
+  }
+
+  if (days.length && days[0].date === dateStr) {
+    console.error(`Latest entry is already ${dateStr}. Nothing to add.`);
+    process.exit(1);
+  }
+
+  const entry = { date: dateStr, ...templateFromPrevious(days[0]) };
+  days.unshift(entry);
+
+  const out = JSON.stringify(data, null, 2) + '\n';
+  fs.writeFileSync(dataPath, out, 'utf8');
+  console.log(`Added ${dateStr} at the top of days (edit ${path.basename(dataPath)} to fill in).`);
+}
+
+main();

--- a/sleep-data.json
+++ b/sleep-data.json
@@ -1,12 +1,30 @@
 {
   "days": [
     {
+      "date": "3/21",
+      "bed": "22:30",
+      "sleepStart": "22:40",
+      "sleepEnd": "7:11",
+      "bathroom": [
+        "3:58"
+      ],
+      "alarm": [
+        "7:02"
+      ],
+      "sick": [],
+      "nap": null
+    },
+    {
       "date": "3/20",
       "bed": "22:38",
       "sleepStart": "22:55",
       "sleepEnd": "7:11",
-      "bathroom": ["3:45"],
-      "alarm": ["7:03"],
+      "bathroom": [
+        "3:45"
+      ],
+      "alarm": [
+        "7:03"
+      ],
       "sick": [],
       "nap": null
     },
@@ -15,8 +33,12 @@
       "bed": "22:28",
       "sleepStart": "22:43",
       "sleepEnd": "7:04",
-      "bathroom": ["1:03"],
-      "alarm": ["7:05"],
+      "bathroom": [
+        "1:03"
+      ],
+      "alarm": [
+        "7:05"
+      ],
       "sick": [],
       "nap": null
     },
@@ -25,8 +47,12 @@
       "bed": "22:22",
       "sleepStart": "22:53",
       "sleepEnd": "7:11",
-      "bathroom": ["3:30"],
-      "alarm": ["7:10"],
+      "bathroom": [
+        "3:30"
+      ],
+      "alarm": [
+        "7:10"
+      ],
       "sick": [],
       "nap": null
     },
@@ -35,8 +61,14 @@
       "bed": "23:05",
       "sleepStart": "23:40",
       "sleepEnd": "8:12",
-      "bathroom": ["5:15"],
-      "alarm": ["7:00","7:15","7:54"],
+      "bathroom": [
+        "5:15"
+      ],
+      "alarm": [
+        "7:00",
+        "7:15",
+        "7:54"
+      ],
       "sick": [],
       "nap": {
         "start": "18:40",
@@ -48,7 +80,9 @@
       "bed": "21:20",
       "sleepStart": "21:35",
       "sleepEnd": "7:19",
-      "bathroom": ["6:10"],
+      "bathroom": [
+        "6:10"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -58,7 +92,9 @@
       "bed": "23:00",
       "sleepStart": "23:50",
       "sleepEnd": "7:38",
-      "bathroom": ["2:25"],
+      "bathroom": [
+        "2:25"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -68,7 +104,9 @@
       "bed": "23:40",
       "sleepStart": "00:00",
       "sleepEnd": "7:48",
-      "bathroom": ["3:30"],
+      "bathroom": [
+        "3:30"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -78,8 +116,12 @@
       "bed": "22:30",
       "sleepStart": "22:48",
       "sleepEnd": "7:11",
-      "bathroom": ["4:45"],
-      "alarm": ["7:00"],
+      "bathroom": [
+        "4:45"
+      ],
+      "alarm": [
+        "7:00"
+      ],
       "sick": [],
       "nap": {
         "start": "17:10",
@@ -91,8 +133,12 @@
       "bed": "21:47",
       "sleepStart": "22:20",
       "sleepEnd": "7:05",
-      "bathroom": ["3:55"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "3:55"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -101,8 +147,12 @@
       "bed": "22:00",
       "sleepStart": "22:40",
       "sleepEnd": "7:13",
-      "bathroom": ["5:20"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "5:20"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": {
         "start": "18:15",
@@ -114,8 +164,12 @@
       "bed": "21:33",
       "sleepStart": "22:00",
       "sleepEnd": "7:07",
-      "bathroom": ["3:05"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "3:05"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -124,8 +178,12 @@
       "bed": "21:52",
       "sleepStart": "22:10",
       "sleepEnd": "7:00",
-      "bathroom": ["1:42"],
-      "alarm": ["6:55"],
+      "bathroom": [
+        "1:42"
+      ],
+      "alarm": [
+        "6:55"
+      ],
       "sick": [],
       "nap": null
     },
@@ -134,8 +192,12 @@
       "bed": "22:50",
       "sleepStart": "23:10",
       "sleepEnd": "7:12",
-      "bathroom": ["0:20"],
-      "alarm": ["7:05"],
+      "bathroom": [
+        "0:20"
+      ],
+      "alarm": [
+        "7:05"
+      ],
       "sick": [],
       "nap": null
     },
@@ -145,7 +207,9 @@
       "sleepStart": "22:50",
       "sleepEnd": "7:15",
       "bathroom": [],
-      "alarm": ["7:15"],
+      "alarm": [
+        "7:15"
+      ],
       "sick": [],
       "nap": null
     },
@@ -154,8 +218,12 @@
       "bed": "22:30",
       "sleepStart": "22:50",
       "sleepEnd": "7:05",
-      "bathroom": ["6:00"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "6:00"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -165,7 +233,9 @@
       "sleepStart": "23:00",
       "sleepEnd": "7:10",
       "bathroom": [],
-      "alarm": ["6:46"],
+      "alarm": [
+        "6:46"
+      ],
       "sick": [],
       "nap": null
     },
@@ -174,8 +244,12 @@
       "bed": "21:40",
       "sleepStart": "22:10",
       "sleepEnd": "7:00",
-      "bathroom": ["1:45"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "1:45"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": {
         "start": "18:00",
@@ -187,8 +261,12 @@
       "bed": "21:40",
       "sleepStart": "22:00",
       "sleepEnd": "6:55",
-      "bathroom": ["2:00"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "2:00"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -197,8 +275,12 @@
       "bed": "22:10",
       "sleepStart": "22:30",
       "sleepEnd": "7:00",
-      "bathroom": ["1:35"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "1:35"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -207,8 +289,12 @@
       "bed": "23:00",
       "sleepStart": "23:30",
       "sleepEnd": "9:40",
-      "bathroom": ["5:45"],
-      "alarm": ["7:05"],
+      "bathroom": [
+        "5:45"
+      ],
+      "alarm": [
+        "7:05"
+      ],
       "sick": [],
       "nap": null
     },
@@ -218,7 +304,9 @@
       "sleepStart": "0:50",
       "sleepEnd": "7:15",
       "bathroom": [],
-      "alarm": ["7:15"],
+      "alarm": [
+        "7:15"
+      ],
       "sick": [],
       "nap": {
         "start": "15:00",
@@ -230,8 +318,12 @@
       "bed": "0:30",
       "sleepStart": "0:45",
       "sleepEnd": "8:00",
-      "bathroom": ["6:20"],
-      "alarm": ["7:40"],
+      "bathroom": [
+        "6:20"
+      ],
+      "alarm": [
+        "7:40"
+      ],
       "sick": [],
       "nap": {
         "start": "15:30",
@@ -243,8 +335,12 @@
       "bed": "23:20",
       "sleepStart": "23:50",
       "sleepEnd": "7:40",
-      "bathroom": ["3:30"],
-      "alarm": ["7:30"],
+      "bathroom": [
+        "3:30"
+      ],
+      "alarm": [
+        "7:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -253,8 +349,12 @@
       "bed": "22:00",
       "sleepStart": "22:20",
       "sleepEnd": "6:50",
-      "bathroom": ["5:45"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "5:45"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -263,8 +363,12 @@
       "bed": "22:50",
       "sleepStart": "23:20",
       "sleepEnd": "6:50",
-      "bathroom": ["2:30"],
-      "alarm": ["6:50"],
+      "bathroom": [
+        "2:30"
+      ],
+      "alarm": [
+        "6:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -273,8 +377,12 @@
       "bed": "22:40",
       "sleepStart": "23:00",
       "sleepEnd": "7:20",
-      "bathroom": ["3:00"],
-      "alarm": ["7:00"],
+      "bathroom": [
+        "3:00"
+      ],
+      "alarm": [
+        "7:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -283,8 +391,14 @@
       "bed": "22:45",
       "sleepStart": "22:45",
       "sleepEnd": "7:30",
-      "bathroom": ["3:30", "6:00"],
-      "alarm": ["7:15", "7:25"],
+      "bathroom": [
+        "3:30",
+        "6:00"
+      ],
+      "alarm": [
+        "7:15",
+        "7:25"
+      ],
       "sick": [],
       "nap": {
         "start": "12:10",
@@ -296,8 +410,12 @@
       "bed": "22:40",
       "sleepStart": "22:55",
       "sleepEnd": "7:40",
-      "bathroom": ["5:20"],
-      "alarm": ["7:15"],
+      "bathroom": [
+        "5:20"
+      ],
+      "alarm": [
+        "7:15"
+      ],
       "sick": [],
       "nap": null
     },
@@ -306,8 +424,12 @@
       "bed": "22:05",
       "sleepStart": "22:35",
       "sleepEnd": "7:00",
-      "bathroom": ["6:30"],
-      "alarm": ["6:40"],
+      "bathroom": [
+        "6:30"
+      ],
+      "alarm": [
+        "6:40"
+      ],
       "sick": [],
       "nap": null
     },
@@ -317,7 +439,9 @@
       "sleepStart": "22:55",
       "sleepEnd": "7:20",
       "bathroom": [],
-      "alarm": ["7:10"],
+      "alarm": [
+        "7:10"
+      ],
       "sick": [],
       "nap": {
         "start": "18:10",
@@ -330,7 +454,9 @@
       "sleepStart": "22:50",
       "sleepEnd": "7:20",
       "bathroom": [],
-      "alarm": ["7:15"],
+      "alarm": [
+        "7:15"
+      ],
       "sick": [],
       "nap": null
     },
@@ -349,8 +475,15 @@
       "bed": "23:10",
       "sleepStart": "23:20",
       "sleepEnd": "08:00",
-      "bathroom": ["4:00"],
-      "alarm": ["7:10", "7:20", "7:30", "08:00"],
+      "bathroom": [
+        "4:00"
+      ],
+      "alarm": [
+        "7:10",
+        "7:20",
+        "7:30",
+        "08:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -359,8 +492,13 @@
       "bed": "23:40",
       "sleepStart": "23:50",
       "sleepEnd": "8:20",
-      "bathroom": ["3:50", "6:50"],
-      "alarm": ["7:50"],
+      "bathroom": [
+        "3:50",
+        "6:50"
+      ],
+      "alarm": [
+        "7:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -369,8 +507,12 @@
       "bed": "0:00",
       "sleepStart": "0:20",
       "sleepEnd": "9:05",
-      "bathroom": ["6:40"],
-      "alarm": ["07:30"],
+      "bathroom": [
+        "6:40"
+      ],
+      "alarm": [
+        "07:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -380,7 +522,9 @@
       "sleepStart": "23:20",
       "sleepEnd": "7:30",
       "bathroom": [],
-      "alarm": ["7:20"],
+      "alarm": [
+        "7:20"
+      ],
       "sick": [],
       "nap": null
     },
@@ -389,8 +533,12 @@
       "bed": "23:00",
       "sleepStart": "23:20",
       "sleepEnd": "07:40",
-      "bathroom": ["05:05"],
-      "alarm": ["07:30"],
+      "bathroom": [
+        "05:05"
+      ],
+      "alarm": [
+        "07:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -399,8 +547,12 @@
       "bed": "23:30",
       "sleepStart": "00:10",
       "sleepEnd": "08:00",
-      "bathroom": ["05:50"],
-      "alarm": ["07:45"],
+      "bathroom": [
+        "05:50"
+      ],
+      "alarm": [
+        "07:45"
+      ],
       "sick": [],
       "nap": {
         "start": "16:00",
@@ -412,8 +564,12 @@
       "bed": "23:00",
       "sleepStart": "23:35",
       "sleepEnd": "08:20",
-      "bathroom": ["03:30"],
-      "alarm": ["08:15"],
+      "bathroom": [
+        "03:30"
+      ],
+      "alarm": [
+        "08:15"
+      ],
       "sick": [],
       "nap": null
     },
@@ -423,7 +579,9 @@
       "sleepStart": "00:10",
       "sleepEnd": "08:00",
       "bathroom": [],
-      "alarm": ["07:50"],
+      "alarm": [
+        "07:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -432,8 +590,12 @@
       "bed": "23:40",
       "sleepStart": "00:20",
       "sleepEnd": "08:30",
-      "bathroom": ["03:30"],
-      "alarm": ["08:30"],
+      "bathroom": [
+        "03:30"
+      ],
+      "alarm": [
+        "08:30"
+      ],
       "sick": [],
       "nap": {
         "start": "15:20",
@@ -445,8 +607,13 @@
       "bed": "23:40",
       "sleepStart": "00:00",
       "sleepEnd": "08:45",
-      "bathroom": ["03:30"],
-      "alarm": ["08:10", "08:30"],
+      "bathroom": [
+        "03:30"
+      ],
+      "alarm": [
+        "08:10",
+        "08:30"
+      ],
       "sick": [],
       "nap": {
         "start": "18:10",
@@ -468,8 +635,12 @@
       "bed": "23:20",
       "sleepStart": "00:40",
       "sleepEnd": "08:45",
-      "bathroom": ["06:50"],
-      "alarm": ["08:40"],
+      "bathroom": [
+        "06:50"
+      ],
+      "alarm": [
+        "08:40"
+      ],
       "sick": [],
       "nap": null
     },
@@ -478,8 +649,13 @@
       "bed": "22:30",
       "sleepStart": "22:50",
       "sleepEnd": "09:20",
-      "bathroom": ["01:00", "06:00"],
-      "alarm": ["08:40"],
+      "bathroom": [
+        "01:00",
+        "06:00"
+      ],
+      "alarm": [
+        "08:40"
+      ],
       "sick": [],
       "nap": null
     },
@@ -488,8 +664,12 @@
       "bed": "23:40",
       "sleepStart": "00:10",
       "sleepEnd": "08:50",
-      "bathroom": ["06:10"],
-      "alarm": ["08:50"],
+      "bathroom": [
+        "06:10"
+      ],
+      "alarm": [
+        "08:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -498,8 +678,12 @@
       "bed": "23:15",
       "sleepStart": "23:50",
       "sleepEnd": "09:05",
-      "bathroom": ["06:00"],
-      "alarm": ["09:00"],
+      "bathroom": [
+        "06:00"
+      ],
+      "alarm": [
+        "09:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -508,7 +692,9 @@
       "bed": "23:30",
       "sleepStart": "00:45",
       "sleepEnd": "09:20",
-      "bathroom": ["06:00"],
+      "bathroom": [
+        "06:00"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -520,7 +706,10 @@
       "sleepEnd": "09:30",
       "bathroom": [],
       "alarm": [],
-      "sick": ["04:00", "04:30"],
+      "sick": [
+        "04:00",
+        "04:30"
+      ],
       "nap": {
         "start": "17:00",
         "end": "17:45"
@@ -551,8 +740,12 @@
       "bed": "23:05",
       "sleepStart": "23:45",
       "sleepEnd": "09:30",
-      "bathroom": ["02:20"],
-      "alarm": ["09:20"],
+      "bathroom": [
+        "02:20"
+      ],
+      "alarm": [
+        "09:20"
+      ],
       "sick": [],
       "nap": null
     },
@@ -561,8 +754,12 @@
       "bed": "23:25",
       "sleepStart": "00:30",
       "sleepEnd": "09:35",
-      "bathroom": ["05:45"],
-      "alarm": ["09:30"],
+      "bathroom": [
+        "05:45"
+      ],
+      "alarm": [
+        "09:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -571,8 +768,12 @@
       "bed": "23:30",
       "sleepStart": "00:30",
       "sleepEnd": "09:45",
-      "bathroom": ["04:50"],
-      "alarm": ["09:30"],
+      "bathroom": [
+        "04:50"
+      ],
+      "alarm": [
+        "09:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -581,7 +782,9 @@
       "bed": "00:00",
       "sleepStart": "00:50",
       "sleepEnd": "10:40",
-      "bathroom": ["06:30"],
+      "bathroom": [
+        "06:30"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -591,10 +794,12 @@
       "bed": "23:50",
       "sleepStart": "00:30",
       "sleepEnd": "09:55",
-      "bathroom": ["04:30"],
+      "bathroom": [
+        "04:30"
+      ],
       "alarm": [],
       "sick": [],
-      "nap":{
+      "nap": {
         "start": "17:00",
         "end": "17:40"
       }
@@ -604,8 +809,13 @@
       "bed": "22:50",
       "sleepStart": "01:20",
       "sleepEnd": "09:55",
-      "bathroom": ["07:50"],
-      "alarm": ["09:15", "09:45"],
+      "bathroom": [
+        "07:50"
+      ],
+      "alarm": [
+        "09:15",
+        "09:45"
+      ],
       "sick": [],
       "nap": null
     },
@@ -614,8 +824,13 @@
       "bed": "23:30",
       "sleepStart": "00:10",
       "sleepEnd": "10:00",
-      "bathroom": ["08:50"],
-      "alarm": ["09:00", "09:30"],
+      "bathroom": [
+        "08:50"
+      ],
+      "alarm": [
+        "09:00",
+        "09:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -624,8 +839,13 @@
       "bed": "23:50",
       "sleepStart": "01:00",
       "sleepEnd": "10:10",
-      "bathroom": ["04:50"],
-      "alarm": ["09:30", "10:00"],
+      "bathroom": [
+        "04:50"
+      ],
+      "alarm": [
+        "09:30",
+        "10:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -634,8 +854,13 @@
       "bed": "00:25",
       "sleepStart": "01:10",
       "sleepEnd": "10:30",
-      "bathroom": ["07:00"],
-      "alarm": ["09:30", "10:00"],
+      "bathroom": [
+        "07:00"
+      ],
+      "alarm": [
+        "09:30",
+        "10:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -644,8 +869,16 @@
       "bed": "00:25",
       "sleepStart": "00:50",
       "sleepEnd": "11:15",
-      "bathroom": ["02:45", "06:15"],
-      "alarm": ["09:00", "09:30", "09:40", "10:00"],
+      "bathroom": [
+        "02:45",
+        "06:15"
+      ],
+      "alarm": [
+        "09:00",
+        "09:30",
+        "09:40",
+        "10:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -654,7 +887,9 @@
       "bed": "01:45",
       "sleepStart": "01:45",
       "sleepEnd": "11:50",
-      "bathroom": ["04:50"],
+      "bathroom": [
+        "04:50"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -674,8 +909,13 @@
       "bed": "22:40",
       "sleepStart": "02:10",
       "sleepEnd": "10:10",
-      "bathroom": ["04:40"],
-      "alarm": ["09:00", "10:00"],
+      "bathroom": [
+        "04:40"
+      ],
+      "alarm": [
+        "09:00",
+        "10:00"
+      ],
       "sick": [],
       "nap": null
     },
@@ -684,8 +924,13 @@
       "bed": "00:30",
       "sleepStart": "01:50",
       "sleepEnd": "10:10",
-      "bathroom": ["05:50"],
-      "alarm": ["09:00", "09:30"],
+      "bathroom": [
+        "05:50"
+      ],
+      "alarm": [
+        "09:00",
+        "09:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -695,7 +940,10 @@
       "sleepStart": "05:15",
       "sleepEnd": "10:30",
       "bathroom": [],
-      "alarm": ["09:30", "10:15"],
+      "alarm": [
+        "09:30",
+        "10:15"
+      ],
       "sick": [],
       "nap": null
     },
@@ -705,7 +953,9 @@
       "sleepStart": "02:00",
       "sleepEnd": "08:50",
       "bathroom": [],
-      "alarm": ["08:30"],
+      "alarm": [
+        "08:30"
+      ],
       "sick": [],
       "nap": {
         "start": "18:15",
@@ -717,7 +967,9 @@
       "bed": "00:40",
       "sleepStart": "01:50",
       "sleepEnd": "15:00",
-      "bathroom": ["07:00"],
+      "bathroom": [
+        "07:00"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -727,9 +979,17 @@
       "bed": "01:00",
       "sleepStart": "01:00",
       "sleepEnd": "13:30",
-      "bathroom": ["06:45"],
+      "bathroom": [
+        "06:45"
+      ],
       "alarm": [],
-      "sick": ["02:00", "02:30", "03:00", "03:30", "05:00"],
+      "sick": [
+        "02:00",
+        "02:30",
+        "03:00",
+        "03:30",
+        "05:00"
+      ],
       "nap": null
     },
     {
@@ -737,7 +997,9 @@
       "bed": "02:00",
       "sleepStart": "03:00",
       "sleepEnd": "14:00",
-      "bathroom": ["10:10"],
+      "bathroom": [
+        "10:10"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -748,7 +1010,9 @@
       "sleepStart": "01:40",
       "sleepEnd": "10:50",
       "bathroom": [],
-      "alarm": ["09:50"],
+      "alarm": [
+        "09:50"
+      ],
       "sick": [],
       "nap": null
     },
@@ -757,8 +1021,13 @@
       "bed": "01:50",
       "sleepStart": "02:10",
       "sleepEnd": "10:50",
-      "bathroom": ["06:45"],
-      "alarm": ["09:50", "10:20"],
+      "bathroom": [
+        "06:45"
+      ],
+      "alarm": [
+        "09:50",
+        "10:20"
+      ],
       "sick": [],
       "nap": null
     },
@@ -767,8 +1036,14 @@
       "bed": "01:45",
       "sleepStart": "02:00",
       "sleepEnd": "10:50",
-      "bathroom": ["03:45"],
-      "alarm": ["08:50", "09:00", "09:15"],
+      "bathroom": [
+        "03:45"
+      ],
+      "alarm": [
+        "08:50",
+        "09:00",
+        "09:15"
+      ],
       "sick": [],
       "nap": null
     },
@@ -777,8 +1052,15 @@
       "bed": "02:20",
       "sleepStart": "02:40",
       "sleepEnd": "12:00",
-      "bathroom": ["06:20"],
-      "alarm": ["09:20", "10:00", "10:45", "11:30"],
+      "bathroom": [
+        "06:20"
+      ],
+      "alarm": [
+        "09:20",
+        "10:00",
+        "10:45",
+        "11:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -788,7 +1070,11 @@
       "sleepStart": "02:40",
       "sleepEnd": "11:00",
       "bathroom": [],
-      "alarm": ["09:30", "10:00", "10:30"],
+      "alarm": [
+        "09:30",
+        "10:00",
+        "10:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -797,7 +1083,9 @@
       "bed": "03:00",
       "sleepStart": "04:00",
       "sleepEnd": "14:20",
-      "bathroom": ["10:20"],
+      "bathroom": [
+        "10:20"
+      ],
       "alarm": [],
       "sick": [],
       "nap": null
@@ -807,8 +1095,16 @@
       "bed": "03:15",
       "sleepStart": "04:30",
       "sleepEnd": "13:45",
-      "bathroom": ["06:40"],
-      "alarm": ["10:40", "11:15", "11:40", "12:30", "13:30"],
+      "bathroom": [
+        "06:40"
+      ],
+      "alarm": [
+        "10:40",
+        "11:15",
+        "11:40",
+        "12:30",
+        "13:30"
+      ],
       "sick": [],
       "nap": null
     },
@@ -817,8 +1113,12 @@
       "bed": "03:30",
       "sleepStart": "04:40",
       "sleepEnd": "12:10",
-      "bathroom": ["09:00"],
-      "alarm": ["11:15"],
+      "bathroom": [
+        "09:00"
+      ],
+      "alarm": [
+        "11:15"
+      ],
       "sick": [],
       "nap": {
         "start": "19:30",
@@ -830,8 +1130,13 @@
       "bed": "04:30",
       "sleepStart": "05:30",
       "sleepEnd": "12:40",
-      "bathroom": ["11:20"],
-      "alarm": ["10:00", "12:20"],
+      "bathroom": [
+        "11:20"
+      ],
+      "alarm": [
+        "10:00",
+        "12:20"
+      ],
       "sick": [],
       "nap": null
     }

--- a/sleep-utils.js
+++ b/sleep-utils.js
@@ -46,8 +46,14 @@ function formatTime(minutes, shortMidnight = false) {
   const total = ((Math.round(minutes) % 1440) + 1440) % 1440;
   const hours = Math.floor(total / 60);
   const mins = total % 60;
-  if (shortMidnight && hours === 0) {
+  const clockFormat = getClockFormatPreference();
+  if (clockFormat === '24h' && shortMidnight && hours === 0) {
     return `00`;
+  }
+  if (clockFormat === '12h') {
+    const hour12 = hours % 12 || 12;
+    const ampm = hours < 12 ? 'AM' : 'PM';
+    return `${hour12}:${String(mins).padStart(2, '0')} ${ampm}`;
   }
   return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
 }
@@ -290,6 +296,7 @@ function evaluatePolynomial(coefficients, x) {
 
 // Project repo (used in nav bar)
 const GITHUB_REPO_URL = 'https://github.com/rsairu/sleep/';
+const DEV_BANNER_OVERRIDE_KEY = 'sleep-app-force-dev-banner';
 
 // Day/night mode: sunrise and sunset in local time (hours 0-23, minutes 0-59)
 const SUNRISE_MINUTES = 6 * 60;
@@ -297,35 +304,36 @@ const SUNSET_MINUTES = 18 * 60;
 
 const THEME_OVERRIDE_KEY = 'sleep-app-theme-override';
 const REMAINING_WAKE_THRESHOLDS_KEY = 'sleep-app-remaining-wake-thresholds';
+const CLOCK_FORMAT_KEY = 'sleep-app-clock-format';
 
 // Default remaining wake phase thresholds (percent of wake time remaining): open >= openMin, winding >= windingMin, presleep < windingMin.
-const DEFAULT_REMAINING_WAKE_OPEN_MIN = 30;
-const DEFAULT_REMAINING_WAKE_WINDING_MIN = 10;
+const DEFAULT_REMAINING_WAKE_OPEN_MIN = 35;
+const DEFAULT_REMAINING_WAKE_WINDING_MIN = 15;
 
-// Returns { openMin, windingMin } from localStorage or defaults. Values are in 0–100, step 5.
+// Returns { openMin, windingMin } from localStorage or defaults. Values are in 0–100, step 1.
 function getRemainingWakeThresholds() {
   try {
     const raw = localStorage.getItem(REMAINING_WAKE_THRESHOLDS_KEY);
     if (raw) {
       const o = JSON.parse(raw);
-      const openMin = clampThresholdStep5(typeof o.openMin === 'number' ? o.openMin : DEFAULT_REMAINING_WAKE_OPEN_MIN);
-      const windingMin = clampThresholdStep5(typeof o.windingMin === 'number' ? o.windingMin : DEFAULT_REMAINING_WAKE_WINDING_MIN);
+      const openMin = clampThresholdPercent(typeof o.openMin === 'number' ? o.openMin : DEFAULT_REMAINING_WAKE_OPEN_MIN);
+      const windingMin = clampThresholdPercent(typeof o.windingMin === 'number' ? o.windingMin : DEFAULT_REMAINING_WAKE_WINDING_MIN);
       if (openMin > windingMin) return { openMin, windingMin };
     }
   } catch (_) {}
   return { openMin: DEFAULT_REMAINING_WAKE_OPEN_MIN, windingMin: DEFAULT_REMAINING_WAKE_WINDING_MIN };
 }
 
-function clampThresholdStep5(n) {
-  const step = 5;
+function clampThresholdPercent(n) {
+  const step = 1;
   const v = Math.round(n / step) * step;
   return Math.min(100, Math.max(0, v));
 }
 
 // Saves thresholds to localStorage. openMin and windingMin must satisfy openMin > windingMin.
 function setRemainingWakeThresholds(openMin, windingMin) {
-  openMin = clampThresholdStep5(openMin);
-  windingMin = clampThresholdStep5(windingMin);
+  openMin = clampThresholdPercent(openMin);
+  windingMin = clampThresholdPercent(windingMin);
   if (openMin <= windingMin) return;
   try {
     localStorage.setItem(REMAINING_WAKE_THRESHOLDS_KEY, JSON.stringify({ openMin, windingMin }));
@@ -354,6 +362,22 @@ function setThemeOverride(theme) {
   try {
     if (theme === null) localStorage.removeItem(THEME_OVERRIDE_KEY);
     else localStorage.setItem(THEME_OVERRIDE_KEY, theme);
+  } catch (_) {}
+}
+
+function getClockFormatPreference() {
+  try {
+    const value = localStorage.getItem(CLOCK_FORMAT_KEY);
+    return value === '12h' || value === '24h' ? value : '24h';
+  } catch (_) {
+    return '24h';
+  }
+}
+
+function setClockFormatPreference(format) {
+  if (format !== '12h' && format !== '24h') return;
+  try {
+    localStorage.setItem(CLOCK_FORMAT_KEY, format);
   } catch (_) {}
 }
 
@@ -468,6 +492,39 @@ function updateThemeSelectors() {
   });
 }
 
+function updateClockFormatSelector() {
+  const wrap = document.getElementById('config-clock');
+  if (!wrap) return;
+  const selected = getClockFormatPreference();
+  wrap.querySelectorAll('.about-theme-option').forEach(btn => {
+    const isActive = btn.getAttribute('data-clock-format') === selected;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive);
+  });
+}
+
+function initClockFormatSelector() {
+  const wrap = document.getElementById('config-clock');
+  if (!wrap) return;
+  updateClockFormatSelector();
+  wrap.addEventListener('click', function (e) {
+    const btn = e.target.closest('.about-theme-option');
+    if (!btn) return;
+    const format = btn.getAttribute('data-clock-format');
+    if (format !== '12h' && format !== '24h') return;
+    setClockFormatPreference(format);
+    updateClockFormatSelector();
+    const inputOpen = document.getElementById('config-open-min');
+    const inputWinding = document.getElementById('config-winding-min');
+    if (inputOpen && inputWinding) {
+      const p1 = parseInt(inputOpen.value, 10);
+      const p2 = parseInt(inputWinding.value, 10);
+      applyRemainingWakeThresholdsUI(p1, p2);
+    }
+    document.dispatchEvent(new CustomEvent('clock-format-changed', { detail: { format } }));
+  });
+}
+
 // Initializes the Config page theme selector: inject Light/Dark toggle, attach row and Auto handlers.
 function initConfigThemeSelector() {
   const wrap = document.getElementById('config-theme');
@@ -551,7 +608,7 @@ function applyRemainingWakeThresholdsUI(pos1, pos2) {
   if (!segOpen || !segWinding || !segPresleep || !iconOpen || !iconWinding || !iconPresleep || !inputOpen || !inputWinding) return;
 
   const p1 = Math.min(95, Math.max(5, pos1));
-  const p2 = Math.min(100, Math.max(p1 + 5, pos2));
+  const p2 = Math.min(100, Math.max(p1 + 1, pos2));
 
   segOpen.style.flex = '0 0 ' + p1 + '%';
   segWinding.style.flex = '0 0 ' + (p2 - p1) + '%';
@@ -567,8 +624,12 @@ function applyRemainingWakeThresholdsUI(pos1, pos2) {
   const basis = configRemainingWakeBasis;
   const clockOpen = basis ? wakePercentToClockMinutes(basis, openMin) : null;
   const clockWinding = basis ? wakePercentToClockMinutes(basis, windingMin) : null;
+  const clockWake = basis ? basis.avgSleepEnd : null;
+  const clockSleep = basis ? basis.avgSleepStart : null;
   const timeOpen = clockOpen != null ? formatTime(clockOpen) : '—';
   const timeWinding = clockWinding != null ? formatTime(clockWinding) : '—';
+  const timeWake = clockWake != null ? formatTime(clockWake) : '—';
+  const timeSleep = clockSleep != null ? formatTime(clockSleep) : '—';
 
   const percentLeft = document.getElementById('config-rw-percent-left');
   const percentRight = document.getElementById('config-rw-percent-right');
@@ -594,11 +655,16 @@ function applyRemainingWakeThresholdsUI(pos1, pos2) {
       'Winding down until ' + windingMin + '% wake time remains, around ' + timeWinding + ' with your 7-day averages'
     );
   }
+
+  const endWakeTime = document.getElementById('config-rw-end-wake-time');
+  const endSleepTime = document.getElementById('config-rw-end-sleep-time');
+  if (endWakeTime) endWakeTime.textContent = timeWake;
+  if (endSleepTime) endSleepTime.textContent = timeSleep;
 }
 
-// Snap value to 0, 5, 10, ... 100
-function snapPercentTo5(frac) {
-  const v = Math.round(frac * 20) * 5;
+// Snap value to 0, 1, 2, ... 100
+function snapPercentTo1(frac) {
+  const v = Math.round(frac * 100);
   return Math.min(100, Math.max(0, v));
 }
 
@@ -623,12 +689,13 @@ function getRemainingWakeThresholdsControlHTML(ariaLabelledBy) {
     '<div class="config-remaining-wake-seg config-remaining-wake-seg--winding" id="config-rw-seg-winding"></div>' +
     '<div class="config-remaining-wake-seg config-remaining-wake-seg--presleep" id="config-rw-seg-presleep"></div>' +
     '</div>' +
-    '<input type="range" id="config-open-min" min="0" max="100" step="5" value="70" aria-label="Active / Winding boundary (percent remaining)" tabindex="0">' +
-    '<input type="range" id="config-winding-min" min="0" max="100" step="5" value="90" aria-label="Winding / Pre-sleep boundary (percent remaining)" tabindex="0">' +
+    '<input type="range" id="config-open-min" min="0" max="100" step="1" value="65" aria-label="Active / Winding boundary (percent remaining)" tabindex="0">' +
+    '<input type="range" id="config-winding-min" min="0" max="100" step="1" value="85" aria-label="Winding / Pre-sleep boundary (percent remaining)" tabindex="0">' +
     '<div class="config-remaining-wake-bar-overlay" id="config-rw-bar-overlay" aria-hidden="true"></div>' +
     '</div>' +
     '<div class="config-remaining-wake-labels">' +
-    '<span>Wake</span><span>Sleep</span>' +
+    '<span class="config-rw-end-label"><span class="config-rw-end-title">Wake</span><span class="config-rw-end-time" id="config-rw-end-wake-time" aria-hidden="true">—</span></span>' +
+    '<span class="config-rw-end-label"><span class="config-rw-end-title">Sleep</span><span class="config-rw-end-time" id="config-rw-end-sleep-time" aria-hidden="true">—</span></span>' +
     '</div>' +
     '<div class="config-remaining-wake-percent-under" id="config-rw-percent-under" aria-live="polite">' +
     '<span class="config-rw-percent-thumb" id="config-rw-percent-left">' +
@@ -674,8 +741,8 @@ function initRemainingWakeThresholdsConfig() {
     let p1 = parseInt(inputOpen.value, 10) || 70;
     let p2 = parseInt(inputWinding.value, 10) || 90;
     if (p1 >= p2) {
-      p2 = Math.min(100, p1 + 5);
-      p1 = Math.max(0, p2 - 5);
+      p2 = Math.min(100, p1 + 1);
+      p1 = Math.max(0, p2 - 1);
     }
     applyRemainingWakeThresholdsUI(p1, p2);
     const openMinNew = 100 - p1;
@@ -693,7 +760,7 @@ function initRemainingWakeThresholdsConfig() {
     const rect = barWrap.getBoundingClientRect();
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const frac = (clientX - rect.left) / rect.width;
-    return snapPercentTo5(frac);
+    return snapPercentTo1(frac);
   }
 
   function onPointerDown(e) {
@@ -706,10 +773,10 @@ function initRemainingWakeThresholdsConfig() {
     const mid = (p1 + p2) / 2;
     if (val <= mid) {
       dragging = 'open';
-      inputOpen.value = String(Math.min(p2 - 5, val));
+      inputOpen.value = String(Math.min(p2 - 1, val));
     } else {
       dragging = 'winding';
-      inputWinding.value = String(Math.max(p1 + 5, val));
+      inputWinding.value = String(Math.max(p1 + 1, val));
     }
     syncFromInputs();
   }
@@ -721,9 +788,9 @@ function initRemainingWakeThresholdsConfig() {
     const p1 = parseInt(inputOpen.value, 10);
     const p2 = parseInt(inputWinding.value, 10);
     if (dragging === 'open') {
-      inputOpen.value = String(Math.min(p2 - 5, val));
+      inputOpen.value = String(Math.min(p2 - 1, val));
     } else {
-      inputWinding.value = String(Math.max(p1 + 5, val));
+      inputWinding.value = String(Math.max(p1 + 1, val));
     }
     syncFromInputs();
   }
@@ -826,6 +893,38 @@ function initNavMenu() {
   });
 }
 
+function isLocalDevHost(hostname) {
+  const host = (hostname || '').toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+}
+
+// Optional build-id mismatch gate:
+// - Set <html data-build-id="..."> on each build.
+// - Set <html data-prod-build-id="..."> to your known production ID.
+// Banner appears when running local dev OR when IDs differ.
+function isDevBuildContext() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('devBanner') === '1') return true;
+  if (params.get('devBanner') === '0') return false;
+
+  try {
+    const forced = localStorage.getItem(DEV_BANNER_OVERRIDE_KEY);
+    if (forced === '1') return true;
+    if (forced === '0') return false;
+  } catch (_) {}
+
+  if (isLocalDevHost(window.location.hostname)) return true;
+
+  const html = document.documentElement;
+  const buildId = html ? html.getAttribute('data-build-id') : '';
+  const prodBuildId = html ? html.getAttribute('data-prod-build-id') : '';
+  if (buildId && prodBuildId && buildId !== prodBuildId) return true;
+
+  return false;
+}
+
 // Render navigation bar
 function renderNavBar(currentPage) {
   applyDayNightTheme();
@@ -867,7 +966,10 @@ function renderNavBar(currentPage) {
   const remainingWakeSlot = `<div class="nav-remaining-wake" id="nav-remaining-wake"></div>`;
   const headerRow = `<div class="nav-header nav-header--remaining-wake">${appName}${remainingWakeSlot}${navRight}</div>`;
   const tabsRow = `<div class="nav-tabs-row"><div class="nav-tabs">${navItems}</div></div>`;
-  return `<div class="nav-wrapper nav-wrapper--remaining-wake">${headerRow}${tabsRow}</div>`;
+  const devBanner = isDevBuildContext()
+    ? '<div class="nav-dev-banner" role="status" aria-label="Development build">Dev Build</div>'
+    : '';
+  return `<div class="nav-wrapper nav-wrapper--remaining-wake">${devBanner}${headerRow}${tabsRow}</div>`;
 }
 
 // Phase thresholds from getRemainingWakeThresholds(): open >= openMin%, winding openMin–windingMin%, pre-sleep < windingMin%.
@@ -890,11 +992,9 @@ function getRemainingWakeIcon(phase) {
   }
 }
 
-/** Returns { phase, icon, timeLabel } from raw days (used when daily.js not loaded).
- * Recent 7 days: average get-up and fell-asleep; phase uses minutes-until-sleep vs that wake-window length. */
-function getRemainingWakeDisplayFromDays(days) {
-  if (!days || days.length === 0) return null;
-  const basis = computeRecentSevenDayWakeBasis(days);
+/** Build remaining-wake display from a computed wake basis. */
+function getRemainingWakeDisplayFromBasis(basis) {
+  if (!basis || basis.totalWakeMins <= 0) return null;
   const { avgSleepStart, totalWakeMins } = basis;
   const now = new Date();
   const nowMins = now.getHours() * 60 + now.getMinutes();
@@ -902,16 +1002,36 @@ function getRemainingWakeDisplayFromDays(days) {
   const phase = getRemainingWakePhase(remainingMins, totalWakeMins);
   const icon = getRemainingWakeIcon(phase);
   const timeLabel = formatDuration(Math.round(remainingMins));
-  return { phase, icon, timeLabel };
+  const percentRemaining = totalWakeMins > 0
+    ? Math.min(100, Math.max(0, (remainingMins / totalWakeMins) * 100))
+    : 100;
+  return { phase, icon, timeLabel, percentRemaining };
 }
 
-/** Injects remaining wake into nav and sets phase class on wrapper. Call with { phase, icon, timeLabel }. */
+/** Returns { phase, icon, timeLabel, percentRemaining } from raw days (used when daily.js not loaded).
+ * Recent 7 days: average get-up and fell-asleep; phase uses minutes-until-sleep vs that wake-window length. */
+function getRemainingWakeDisplayFromDays(days) {
+  if (!days || days.length === 0) return null;
+  const basis = computeRecentSevenDayWakeBasis(days);
+  return getRemainingWakeDisplayFromBasis(basis);
+}
+
+/** Injects remaining wake into nav and sets phase class on wrapper. */
 function updateRemainingWakeNav(display) {
   if (!display) return;
   const slot = document.getElementById('nav-remaining-wake');
   const wrapper = document.querySelector('.nav-wrapper');
   if (slot) {
-    slot.innerHTML = `<a href="about.html#remaining-wake-time" class="nav-remaining-wake-link" title="Remaining wake time" aria-label="Remaining wake time"><span class="nav-remaining-wake-icon" aria-hidden="true">${display.icon}</span><span class="nav-remaining-wake-time">${display.timeLabel}</span></a>`;
+    const { openMin, windingMin } = getRemainingWakeThresholds();
+    const p1 = 100 - openMin;
+    const p2 = 100 - windingMin;
+    const progress = typeof display.percentRemaining === 'number'
+      ? Math.min(100, Math.max(0, 100 - display.percentRemaining))
+      : null;
+    const progressBar = progress === null
+      ? ''
+      : `<span class="nav-remaining-wake-progress nav-remaining-wake-progress--${display.phase}" aria-hidden="true" style="--nav-rw-p1:${p1}%;--nav-rw-p2:${p2}%;--nav-rw-progress:${progress}%"><span class="nav-remaining-wake-progress-track"></span><span class="nav-remaining-wake-progress-fill"></span></span>`;
+    slot.innerHTML = `<a href="about.html#remaining-wake-time" class="nav-remaining-wake-link" title="Remaining wake time" aria-label="Remaining wake time"><span class="nav-remaining-wake-main"><span class="nav-remaining-wake-icon" aria-hidden="true">${display.icon}</span><span class="nav-remaining-wake-time">${display.timeLabel}</span></span>${progressBar}</a>`;
   }
   if (wrapper) {
     wrapper.classList.remove('nav-wrapper--phase-open', 'nav-wrapper--phase-winding', 'nav-wrapper--phase-presleep');
@@ -921,11 +1041,21 @@ function updateRemainingWakeNav(display) {
 
 /** Fetches sleep data and fills remaining wake in nav. Call on every page so header is consistent. */
 function initRemainingWakeNav() {
+  const timerKey = '__sleepAppRemainingWakeNavTimer';
+  if (typeof window !== 'undefined' && window[timerKey]) {
+    clearInterval(window[timerKey]);
+    window[timerKey] = null;
+  }
   fetch('sleep-data.json')
     .then(r => r.json())
     .then(data => {
-      const display = getRemainingWakeDisplayFromDays(data.days);
-      updateRemainingWakeNav(display);
+      const basis = computeRecentSevenDayWakeBasis(data.days);
+      updateRemainingWakeNav(getRemainingWakeDisplayFromBasis(basis));
+      if (typeof window !== 'undefined') {
+        window[timerKey] = setInterval(function () {
+          updateRemainingWakeNav(getRemainingWakeDisplayFromBasis(basis));
+        }, 60000);
+      }
     })
     .catch(() => {});
 }

--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,19 @@ body{
   margin-bottom: var(--space-5);
 }
 
+.nav-dev-banner {
+  background: #f97316;
+  color: #ffffff;
+  border-radius: 8px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  padding: 4px 10px;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
 .nav-header {
   background: var(--panel);
   border-radius: var(--panel-radius);
@@ -598,13 +611,20 @@ body{
 
 .nav-remaining-wake-link {
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   color: var(--text);
   text-decoration: none;
   font-weight: 600;
   font-size: 1.125rem;
   transition: opacity 0.2s;
+}
+
+.nav-remaining-wake-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .nav-remaining-wake-link:hover {
@@ -618,6 +638,110 @@ body{
 
 .nav-remaining-wake-time {
   letter-spacing: 0.02em;
+}
+
+.nav-remaining-wake-progress {
+  display: inline-block;
+  flex: 0 0 auto;
+  position: relative;
+  width: clamp(120px, 20vw, 170px);
+  height: 8px;
+  border-radius: 3px;
+  overflow: visible;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="day"] .nav-remaining-wake-progress {
+  border-color: rgba(15, 23, 42, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.nav-remaining-wake-progress-track,
+.nav-remaining-wake-progress-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-color: rgba(255, 255, 255, 0.08);
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0.18) 0 4px,
+      transparent 4px 6px
+    ),
+    linear-gradient(
+      to right,
+      rgba(110, 208, 146, 0.22) 0 var(--nav-rw-p1),
+      rgba(253, 230, 138, 0.25) var(--nav-rw-p1) var(--nav-rw-p2),
+      rgba(196, 181, 253, 0.25) var(--nav-rw-p2) 100%
+    );
+}
+
+.nav-remaining-wake-progress-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: var(--nav-rw-progress);
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.15) 0 4px,
+      transparent 4px 6px
+    );
+  background-color: var(--nav-rw-phase-color, rgb(134, 239, 172));
+}
+
+.nav-remaining-wake-progress-fill::before {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 9px;
+  height: 5px;
+  border-radius: 1px;
+  transform: translate(0, -50%);
+  background: var(--nav-rw-phase-color, rgb(134, 239, 172));
+}
+
+.nav-remaining-wake-progress-fill::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  transform: translate(50%, -50%) scale(1);
+  transform-origin: center;
+  background: color-mix(in srgb, var(--nav-rw-phase-color, rgb(134, 239, 172)) 78%, white 22%);
+  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.24);
+  animation: nav-rw-tip-pulse 2.5s ease-in-out infinite;
+}
+
+.nav-remaining-wake-progress--open {
+  --nav-rw-phase-color: rgb(110, 208, 146);
+}
+
+.nav-remaining-wake-progress--winding {
+  --nav-rw-phase-color: rgb(253, 230, 138);
+}
+
+.nav-remaining-wake-progress--presleep {
+  --nav-rw-phase-color: rgb(196, 181, 253);
+}
+
+@keyframes nav-rw-tip-pulse {
+  0%, 100% {
+    opacity: 0.75;
+    transform: translate(50%, -50%) scale(0.95);
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.16);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(50%, -50%) scale(1.24);
+    box-shadow: 0 0 0 8px rgba(255, 255, 255, 0.32);
+  }
 }
 
 /* Phase-colored header (remaining wake in bar) */
@@ -660,12 +784,42 @@ body{
   min-width: 0;
 }
 
+.dashboard-7d-subtitle {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0 0 8px 4px;
+  opacity: 0.8;
+}
+
 .dashboard-7d-graph-container {
   border-radius: var(--panel-radius);
   border: 1px solid var(--panel-border-color);
   box-shadow: var(--panel-shadow);
   overflow: auto;
   min-height: 280px;
+}
+
+/* Dashboard mobile layout:
+   Tonight -> Month -> Past Week chart 1 -> Past Week chart 2 -> Recent nights */
+@media (max-width: 900px) {
+  .dashboard-top-row,
+  .dashboard-7d-row {
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .dashboard-top-col,
+  .dashboard-7d-col {
+    width: 100%;
+  }
+
+  .dashboard-top-col--calendar {
+    justify-content: flex-start;
+  }
+
+  .dashboard-7d-graph-container {
+    min-height: 240px;
+  }
 }
 
 .dashboard-top-col {
@@ -2515,7 +2669,20 @@ svg {
   fill: currentColor;
 }
 
+.clock-format-icon-text {
+  display: inline-block;
+  font-size: 0.56rem;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
 #theme.section-title {
+  margin-top: 0;
+}
+
+#clock.section-title {
   margin-top: 0;
 }
 
@@ -2725,6 +2892,30 @@ svg {
   font-size: 0.8rem;
   opacity: 0.85;
   margin-top: 0.25rem;
+}
+
+.config-rw-end-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  line-height: 1.15;
+}
+
+.config-rw-end-label:first-child {
+  text-align: left;
+  align-items: flex-start;
+}
+
+.config-rw-end-label:last-child {
+  text-align: right;
+  align-items: flex-end;
+}
+
+.config-rw-end-time {
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.8;
+  white-space: nowrap;
 }
 
 .config-remaining-wake-percent-under {


### PR DESCRIPTION
- Introduced an HP bar beneath the wake timer to visualize daily progress and display the current day
- Added a command to log new day entries into `sleep-data.json`
- Improved dashboard layout responsiveness for mobile devices
- Enabled users to adjust the remaining wake time threshold in 1% increments, with visible start and end of day markers
- Expanded user preferences to include selectable time formats (12-hour AM/PM or 24-hour)
- Added a visual indicator for development builds