### PR TITLE
Sleep flag revamp

### DIFF
--- a/daily.js
+++ b/daily.js
@@ -1,8 +1,15 @@
 // Configuration constants
 const YEAR = 2026;
 const ALARM_TO_WAKE_WARNING_THRESHOLD = 60; // minutes
-const DEVIATION_FLAG_THRESHOLD = 20; // minutes - flags only show if deviation is >= this
-const WAKE_DEVIATION_FLAG_THRESHOLD = 30; // minutes - wake-up time deviation (display only, does not affect sleep quality)
+/** Prior nights required before timing flags or heatmap colors apply. */
+const LOOKBACK_DAYS = 7;
+const DAY_MINUTES = 1440;
+/** Weight when blending sleep-relative vs day-relative variation (internal only). */
+const BLEND_ALPHA = 0.75;
+/** Total sleep (main + nap) below these minute thresholds adds a duration flag (absolute floor; combined with relative short-sleep via max severity, not stacked). */
+const ABS_DURATION_SLIGHT_LT_MIN = 360; // < 6h → slight
+const ABS_DURATION_MODERATE_LT_MIN = 300; // < 5h → moderate
+const ABS_DURATION_SEVERE_LT_MIN = 240; // < 4h → severe
 const DATA_FILES = {
   sleep: 'sleep-data.json'
 };
@@ -111,169 +118,255 @@ function bedMinutesForTimeline(bedMinutes) {
 // Note: normalizeTimeForComparison, normalizeTimeForAveraging, and denormalizeTimeForAveraging 
 // are now in sleep-utils.js
 
+function blendedVariationPercent(diffMinutes, avgSleepDurationMinutes) {
+  const sleepBase = Math.max(avgSleepDurationMinutes, 1);
+  const pctSleep = (diffMinutes / sleepBase) * 100;
+  const pctDay = (diffMinutes / DAY_MINUTES) * 100;
+  return BLEND_ALPHA * pctSleep + (1 - BLEND_ALPHA) * pctDay;
+}
+
+/** @returns {'slight'|'moderate'|'severe'|null} */
+function severityFromBlendedPercent(p) {
+  if (p < 5) return null;
+  if (p < 10) return 'slight';
+  if (p < 19) return 'moderate';
+  return 'severe';
+}
+
+const SEVERITY_RANK = { slight: 1, moderate: 2, severe: 3 };
+
+function maxSeverity(a, b) {
+  if (!a) return b || null;
+  if (!b) return a;
+  return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/** Total sleep minutes (including nap): absolute short-sleep tiers; null if ≥ 6h. */
+function severityFromAbsoluteTotalSleepMinutes(totalMinutes) {
+  if (totalMinutes >= ABS_DURATION_SLIGHT_LT_MIN) return null;
+  if (totalMinutes < ABS_DURATION_SEVERE_LT_MIN) return 'severe';
+  if (totalMinutes < ABS_DURATION_MODERATE_LT_MIN) return 'moderate';
+  return 'slight';
+}
+
+/** Calendar / quality ramp: slight | moderate | severe from WASO count, or null if none. */
+function wasoQualitySeverity(day) {
+  const frag = normalizeFragmentationLevel(day);
+  if (!frag) return null;
+  if (frag === 'mild') return 'slight';
+  if (frag === 'moderate') return 'moderate';
+  return 'severe';
+}
+
 // Calculate recent averages for deviation detection (excluding current day)
-function calculateRecentAverages(days, currentIndex, lookbackDays = 7) {
-  // Get recent days excluding the current day
+function calculateRecentAverages(days, currentIndex, lookbackDays = LOOKBACK_DAYS) {
   const startIndex = Math.max(0, currentIndex + 1);
   const endIndex = Math.min(days.length, currentIndex + 1 + lookbackDays);
   const recentDays = days.slice(startIndex, endIndex);
-  
-  if (recentDays.length === 0) {
-    return null;
+
+  if (recentDays.length < lookbackDays) {
+    return {
+      insufficient: true,
+      sampleSize: recentDays.length
+    };
   }
-  
-  let bedTimeSum = 0;
+
   let fellAsleepTimeSum = 0;
   let wakeTimeSum = 0;
   let sleepDurationSum = 0;
-  
+
   recentDays.forEach(day => {
-    // Normalize bed time before averaging to handle times that cross midnight
-    const bedTime = timeToMinutes(day.bed);
-    const normalizedBedTime = normalizeTimeForComparison(bedTime);
-    bedTimeSum += normalizedBedTime;
-    
-    // Normalize fell asleep before averaging to handle times that cross midnight
     const fellAsleepTime = timeToMinutes(day.sleepStart);
     const normalizedFellAsleepTime = normalizeTimeForAveraging(fellAsleepTime);
     fellAsleepTimeSum += normalizedFellAsleepTime;
-    
+
     const wakeTime = timeToMinutes(day.sleepEnd);
     wakeTimeSum += normalizeWakeTimeForAveraging(fellAsleepTime, wakeTime);
-    
+
     sleepDurationSum += calculateTotalSleep(day);
   });
-  
+
   return {
-    avgBedTime: bedTimeSum / recentDays.length, // This is normalized
-    avgFellAsleepTime: fellAsleepTimeSum / recentDays.length, // This is normalized
-    avgWakeTime: wakeTimeSum / recentDays.length, // Normalized for comparison
+    insufficient: false,
+    avgFellAsleepTime: fellAsleepTimeSum / recentDays.length,
+    avgWakeTime: wakeTimeSum / recentDays.length,
     avgSleepDuration: sleepDurationSum / recentDays.length
   };
 }
 
-// Check for deviations and return warning messages
-function checkDeviations(day, recentAverages) {
-  if (!recentAverages) return [];
-  
-  const warnings = [];
-  
-  // Check bed time (later than average)
-  const bedTime = timeToMinutes(day.bed);
-  const normalizedBedTime = normalizeTimeForComparison(bedTime);
-  // avgBedTime is already normalized from calculateRecentAverages
-  if (normalizedBedTime > recentAverages.avgBedTime) {
-    const diff = normalizedBedTime - recentAverages.avgBedTime;
-    if (diff >= DEVIATION_FLAG_THRESHOLD) {
-      warnings.push(`⚠️🛌 <strong>Bed Time</strong>: ${formatDuration(Math.round(diff))} later than recent average`);
-    }
-  }
-  
-  // Check fell asleep (later than average)
+function analyzeTimingDeviations(day, recentAverages) {
+  const avgSleep = recentAverages.avgSleepDuration;
   const fellAsleepTime = timeToMinutes(day.sleepStart);
-  const normalizedFellAsleepTime = normalizeTimeForAveraging(fellAsleepTime);
-  // avgFellAsleepTime is already normalized from calculateRecentAverages
-  if (normalizedFellAsleepTime > recentAverages.avgFellAsleepTime) {
-    const diff = normalizedFellAsleepTime - recentAverages.avgFellAsleepTime;
-    if (diff >= DEVIATION_FLAG_THRESHOLD) {
-      warnings.push(`⚠️😴 <strong>Asleep</strong>: ${formatDuration(Math.round(diff))} later than recent average`);
-    }
-  }
-  
-  // Check sleep duration (shorter than average)
+  const normalizedFellAsleep = normalizeTimeForAveraging(fellAsleepTime);
+  // Only flag asleep when later than average (earlier is not penalized).
+  const asleepLaterThanAvg = normalizedFellAsleep > recentAverages.avgFellAsleepTime;
+  const asleepDiff = asleepLaterThanAvg
+    ? normalizedFellAsleep - recentAverages.avgFellAsleepTime
+    : 0;
+  const asleepSeverity = asleepLaterThanAvg
+    ? severityFromBlendedPercent(blendedVariationPercent(asleepDiff, avgSleep))
+    : null;
+
   const sleepDuration = calculateTotalSleep(day);
-  if (sleepDuration < recentAverages.avgSleepDuration) {
-    const diff = recentAverages.avgSleepDuration - sleepDuration;
-    if (diff >= DEVIATION_FLAG_THRESHOLD) {
-      warnings.push(`⚠️⌛ <strong>Duration</strong>: ${formatDuration(Math.round(diff))} shorter than recent average`);
-    }
-  }
-  
-  // Check wake-up time deviation (earlier or later than average; display only, does not affect sleep quality)
+  // Relative: only when shorter than average. Absolute: < 6h / < 5h / < 4h. Worst of the two (not additive).
+  const durationShorterThanAvg = sleepDuration < recentAverages.avgSleepDuration;
+  const durDiff = durationShorterThanAvg
+    ? recentAverages.avgSleepDuration - sleepDuration
+    : 0;
+  const relativeDurationSeverity = durationShorterThanAvg
+    ? severityFromBlendedPercent(blendedVariationPercent(durDiff, avgSleep))
+    : null;
+  const absoluteDurationSeverity = severityFromAbsoluteTotalSleepMinutes(sleepDuration);
+  const durationSeverity = maxSeverity(relativeDurationSeverity, absoluteDurationSeverity);
+
   const wakeTime = timeToMinutes(day.sleepEnd);
-  const normalizedWakeTime = normalizeWakeTimeForAveraging(fellAsleepTime, wakeTime);
-  const wakeDiff = Math.abs(normalizedWakeTime - recentAverages.avgWakeTime);
-  if (wakeDiff >= WAKE_DEVIATION_FLAG_THRESHOLD) {
-    const later = normalizedWakeTime > recentAverages.avgWakeTime;
-    warnings.push(`⚠️🌅 <strong>Wake</strong>: ${formatDuration(Math.round(wakeDiff))} ${later ? 'later' : 'earlier'} than recent average`);
+  const normalizedWake = normalizeWakeTimeForAveraging(fellAsleepTime, wakeTime);
+  const wakeDiff = Math.abs(normalizedWake - recentAverages.avgWakeTime);
+  const wakeSeverity = severityFromBlendedPercent(blendedVariationPercent(wakeDiff, avgSleep));
+
+  return {
+    normalizedFellAsleep,
+    asleepDiff,
+    asleepSeverity,
+    sleepDuration,
+    durDiff,
+    durationSeverity,
+    relativeDurationSeverity,
+    absoluteDurationSeverity,
+    normalizedWake,
+    wakeDiff,
+    wakeSeverity
+  };
+}
+
+function computeWorstQualitySeverity(day, recentAverages) {
+  if (!recentAverages || recentAverages.insufficient) return 'none';
+  const t = analyzeTimingDeviations(day, recentAverages);
+  let worst = maxSeverity(t.asleepSeverity, t.durationSeverity);
+  worst = maxSeverity(worst, wasoQualitySeverity(day));
+  return worst || 'none';
+}
+
+/** Prefer explaining whichever source sets combined duration severity (relative vs absolute). */
+function durationDeviationCopy(t) {
+  const abs = t.absoluteDurationSeverity;
+  const rel = t.relativeDurationSeverity;
+  if (!t.durationSeverity) return { html: '', plain: '' };
+  const absDrives = abs && (!rel || SEVERITY_RANK[abs] >= SEVERITY_RANK[rel]);
+  if (absDrives && abs) {
+    if (abs === 'severe') {
+      return { html: '<strong>Duration</strong>: under 4 hours total', plain: 'Duration: under 4 hours total' };
+    }
+    if (abs === 'moderate') {
+      return { html: '<strong>Duration</strong>: under 5 hours total', plain: 'Duration: under 5 hours total' };
+    }
+    return { html: '<strong>Duration</strong>: under 6 hours total', plain: 'Duration: under 6 hours total' };
   }
-  
-  // Fragmentation level from data (display only; does not affect sleep quality)
+  const d = formatDuration(Math.round(t.durDiff));
+  const plain = `Duration: ${d} shorter than recent average`;
+  return { html: `<strong>Duration</strong>: ${d} shorter than recent average`, plain };
+}
+
+function durationDeviationBodyHtml(t) {
+  return durationDeviationCopy(t).html;
+}
+
+// Check for deviations and return warning objects (severity drives CSS; category emoji only, no yield/stop)
+function checkDeviations(day, recentAverages) {
+  if (!recentAverages || recentAverages.insufficient) {
+    return [{
+      severity: 'insufficient',
+      plainSummary: 'Not enough data (need 7 prior nights in the log).',
+      bodyHtml: 'Not enough data (need 7 prior nights in the log).'
+    }];
+  }
+
+  const warnings = [];
+  const t = analyzeTimingDeviations(day, recentAverages);
+
+  if (t.asleepSeverity) {
+    const detail = `${formatDuration(Math.round(t.asleepDiff))} later than recent average`;
+    warnings.push({
+      severity: t.asleepSeverity,
+      emoji: '😴',
+      plainSummary: `Asleep: ${detail}`,
+      bodyHtml: `<strong>Asleep</strong>: ${detail}`
+    });
+  }
+
+  if (t.durationSeverity) {
+    const { html, plain } = durationDeviationCopy(t);
+    warnings.push({
+      severity: t.durationSeverity,
+      emoji: '⌛',
+      plainSummary: plain,
+      bodyHtml: html
+    });
+  }
+
+  if (t.wakeSeverity) {
+    const later = t.normalizedWake > recentAverages.avgWakeTime;
+    const detail = `${formatDuration(Math.round(t.wakeDiff))} ${later ? 'later' : 'earlier'} than recent average`;
+    warnings.push({
+      severity: t.wakeSeverity,
+      emoji: '🌅',
+      plainSummary: `Wake: ${detail}`,
+      bodyHtml: `<strong>Wake</strong>: ${detail}`
+    });
+  }
+
   const fragLevel = normalizeFragmentationLevel(day);
   if (fragLevel) {
-    warnings.push(formatFragmentationDeviationWarning(fragLevel));
+    const fragSeverity = fragLevel === 'mild' ? 'slight' : fragLevel === 'moderate' ? 'moderate' : 'severe';
+    const label = fragSeverity === 'slight' ? 'Slight' : fragSeverity === 'moderate' ? 'Moderate' : 'Severe';
+    warnings.push({
+      severity: fragSeverity,
+      emoji: '🧩',
+      plainSummary: `${label} WASO`,
+      bodyHtml: `<strong>${label}</strong> WASO`
+    });
   }
-  
+
   return warnings;
 }
 
-/** Fragmentation strip: mild matches default alerts; moderate/severe use warmer CSS modifiers. */
-function formatFragmentationDeviationWarning(level) {
-  const cap = level.charAt(0).toUpperCase() + level.slice(1);
-  let extraClass = '';
-  if (level === 'moderate') extraClass = ' deviation-warning--frag-moderate';
-  if (level === 'severe') extraClass = ' deviation-warning--frag-severe';
-  const icon = level === 'severe' ? '🛑🧩' : '⚠️🧩';
-  return {
-    html: `${icon} <strong>${cap}</strong> fragmentation`,
-    extraClass
-  };
+function escapeHtmlAttr(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;');
+}
+
+function escapeHtmlText(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function deviationWarningMarkup(w) {
   if (typeof w === 'string') {
-    return `<div class="deviation-warning">${w}</div>`;
+    return `<button type="button" class="deviation-flag-chip deviation-flag-chip--insufficient" aria-expanded="false" aria-label="${escapeHtmlAttr(w)}"><span class="deviation-flag-chip-icon" aria-hidden="true">⋯</span><span class="deviation-flag-chip-text">${escapeHtmlText(w)}</span></button>`;
   }
-  return `<div class="deviation-warning${w.extraClass || ''}">${w.html}</div>`;
+  const label = w.plainSummary || '';
+  const aria = escapeHtmlAttr(label);
+  if (w.severity === 'insufficient') {
+    return `<button type="button" class="deviation-flag-chip deviation-flag-chip--insufficient" aria-expanded="false" aria-label="${aria}"><span class="deviation-flag-chip-icon" aria-hidden="true">⋯</span><span class="deviation-flag-chip-text">${w.bodyHtml}</span></button>`;
+  }
+  const sevClass = `deviation-flag-chip--${w.severity}`;
+  return `<button type="button" class="deviation-flag-chip ${sevClass}" aria-expanded="false" aria-label="${aria}"><span class="deviation-flag-chip-icon" aria-hidden="true">${w.emoji}</span><span class="deviation-flag-chip-text">${w.bodyHtml}</span></button>`;
 }
 
-// Check for deviations and return flag types with icons
+// Flag emojis for calendar tooltip (timing uses blended % thresholds; 🧩 when WASO ≥ 1)
 function getFlagTypes(day, recentAverages) {
-  if (!recentAverages) return [];
-  
+  if (!recentAverages || recentAverages.insufficient) return [];
+
+  const t = analyzeTimingDeviations(day, recentAverages);
   const flagTypes = [];
-  
-  // Check bed time (later than average)
-  const bedTime = timeToMinutes(day.bed);
-  const normalizedBedTime = normalizeTimeForComparison(bedTime);
-  if (normalizedBedTime > recentAverages.avgBedTime) {
-    const diff = normalizedBedTime - recentAverages.avgBedTime;
-    if (diff >= DEVIATION_FLAG_THRESHOLD) {
-      flagTypes.push('🛌');
-    }
-  }
-  
-  // Check fell asleep (later than average)
-  const fellAsleepTime = timeToMinutes(day.sleepStart);
-  const normalizedFellAsleepTime = normalizeTimeForAveraging(fellAsleepTime);
-  if (normalizedFellAsleepTime > recentAverages.avgFellAsleepTime) {
-    const diff = normalizedFellAsleepTime - recentAverages.avgFellAsleepTime;
-    if (diff >= DEVIATION_FLAG_THRESHOLD) {
-      flagTypes.push('😴');
-    }
-  }
-  
-  // Check sleep duration (shorter than average)
-  const sleepDuration = calculateTotalSleep(day);
-  if (sleepDuration < recentAverages.avgSleepDuration) {
-    const diff = recentAverages.avgSleepDuration - sleepDuration;
-    if (diff >= DEVIATION_FLAG_THRESHOLD) {
-      flagTypes.push('⌛');
-    }
-  }
-  
-  // Check wake-up time deviation (display only, does not affect sleep quality)
-  const wakeTime = timeToMinutes(day.sleepEnd);
-  const normalizedWakeTime = normalizeWakeTimeForAveraging(fellAsleepTime, wakeTime);
-  if (Math.abs(normalizedWakeTime - recentAverages.avgWakeTime) >= WAKE_DEVIATION_FLAG_THRESHOLD) {
-    flagTypes.push('🌅');
-  }
-  
-  // Recorded fragmentation (display only; does not affect sleep quality heatmap count)
-  if (normalizeFragmentationLevel(day)) {
-    flagTypes.push('🧩');
-  }
-  
+  if (t.asleepSeverity) flagTypes.push('😴');
+  if (t.durationSeverity) flagTypes.push('⌛');
+  if (t.wakeSeverity) flagTypes.push('🌅');
+  if (normalizeFragmentationLevel(day)) flagTypes.push('🧩');
   return flagTypes;
 }
 
@@ -347,8 +440,8 @@ function renderDay(day, days, dayIndex, options) {
   // Check for deviations from recent averages
   const recentAverages = calculateRecentAverages(days, dayIndex);
   const deviations = checkDeviations(day, recentAverages);
-  const deviationWarnings = deviations.length > 0 
-    ? `<div class="deviation-warnings">${deviations.map(deviationWarningMarkup).join('')}</div>`
+  const deviationWarnings = deviations.length > 0
+    ? `<div class="deviation-warnings deviation-warnings--chips">${deviations.map(deviationWarningMarkup).join('')}</div>`
     : '';
   
   // Convert times to timeline positions
@@ -398,11 +491,6 @@ function renderDay(day, days, dayIndex, options) {
   day.alarm.forEach(time => {
     const minutes = timeToTimelinePosition(timeToMinutes(time));
     html += `<div class="event alarm" style="--m:${minutes}" data-tooltip="${time} alarm"></div>`;
-  });
-  
-  (day.sick || []).forEach(time => {
-    const minutes = timeToTimelinePosition(timeToMinutes(time));
-    html += `<div class="event sick" style="--m:${minutes}" data-tooltip="${time} sick"></div>`;
   });
   
   day.bathroom.forEach(time => {
@@ -549,28 +637,15 @@ function renderWeek(week, weekIndex, allDays) {
   `;
 }
 
-// Flags that affect sleep quality (heatmap color). Wake and fragmentation are display-only.
-const QUALITY_FLAG_TYPES = ['🛌', '😴', '⌛'];
-
-// Count flags for a specific day (quality-affecting only; wake + fragmentation excluded)
-function countFlagsForDay(day, days, dayIndex) {
-  const flagTypes = getFlagTypesForDay(day, days, dayIndex);
-  return flagTypes.filter(t => QUALITY_FLAG_TYPES.includes(t)).length;
-}
-
-// Get flag types for a specific day
-function getFlagTypesForDay(day, days, dayIndex) {
-  const recentAverages = calculateRecentAverages(days, dayIndex);
-  return getFlagTypes(day, recentAverages);
-}
-
-// Build flag count map for all days
+// Heatmap cell color = worst severity among 😴, ⌛, and 🧩 (WASO); 🌅 is tooltip-only.
 function buildFlagCountMap(days) {
   const flagMap = new Map();
   days.forEach((day, index) => {
-    const flagCount = countFlagsForDay(day, days, index);
-    const flagTypes = getFlagTypesForDay(day, days, index);
-    flagMap.set(day.date, { count: flagCount, types: flagTypes });
+    const recentAverages = calculateRecentAverages(days, index);
+    const insufficient = !recentAverages || recentAverages.insufficient;
+    const types = getFlagTypes(day, recentAverages);
+    const qualitySeverity = insufficient ? 'none' : computeWorstQualitySeverity(day, recentAverages);
+    flagMap.set(day.date, { insufficient, qualitySeverity, types });
   });
   return flagMap;
 }
@@ -623,12 +698,13 @@ function generateCalendarHeatmap(year, flagMap, latestDataDate) {
         flatDays.push(null);
       } else {
         const dateStr = formatDateShort(date);
-        const flagData = flagMap.get(dateStr) || { count: 0, types: [] };
+        const flagData = flagMap.get(dateStr) || { insufficient: false, qualitySeverity: 'none', types: [] };
         flatDays.push({
           date: date,
           dateStr: dateStr,
           day: day,
-          flagCount: flagData.count,
+          insufficient: flagData.insufficient,
+          qualitySeverity: flagData.qualitySeverity,
           flagTypes: flagData.types
         });
       }
@@ -649,7 +725,7 @@ function generateCalendarHeatmap(year, flagMap, latestDataDate) {
       while (last.length < 7) last.push(null);
     }
 
-    const flagCounts = { '🛌': 0, '😴': 0, '⌛': 0, '🌅': 0, '🧩': 0 };
+    const flagCounts = { '😴': 0, '⌛': 0, '🌅': 0, '🧩': 0 };
     flatDays.forEach(day => {
       if (day && day.flagTypes) {
         day.flagTypes.forEach(flagType => {
@@ -669,18 +745,27 @@ function generateCalendarHeatmap(year, flagMap, latestDataDate) {
   return months;
 }
 
-// Get color class for flag count
-function getFlagColorClass(flagCount) {
-  if (flagCount === 0) return 'flag-none';
-  if (flagCount === 1) return 'flag-one';
-  if (flagCount === 2) return 'flag-two';
+function getCalendarSquareColorClass(dayCell) {
+  if (!dayCell) return 'empty';
+  if (dayCell.insufficient) return 'flag-insufficient';
+  const s = dayCell.qualitySeverity || 'none';
+  if (s === 'none') return 'flag-none';
+  if (s === 'slight') return 'flag-one';
+  if (s === 'moderate') return 'flag-two';
   return 'flag-three-plus';
+}
+
+function calendarSquareTooltip(dayCell) {
+  if (dayCell.insufficient) return `${dayCell.dateStr}: not enough data`;
+  if (dayCell.flagTypes && dayCell.flagTypes.length > 0) {
+    return `${dayCell.dateStr}: ${dayCell.flagTypes.join(' ')}`;
+  }
+  return `${dayCell.dateStr}: normal`;
 }
 
 // Render a single month block (for heatmap). large: true adds --large class for 2x size on dashboard.
 function renderMonthBlock(month, large) {
   const flagSlots = [
-    { emoji: '🛌', count: month.flagCounts['🛌'] },
     { emoji: '😴', count: month.flagCounts['😴'] },
     { emoji: '⌛', count: month.flagCounts['⌛'] },
     { emoji: '🌅', count: month.flagCounts['🌅'] },
@@ -703,11 +788,8 @@ function renderMonthBlock(month, large) {
               if (day === null) {
                 return `<div class="calendar-square empty"></div>`;
               }
-              const colorClass = getFlagColorClass(day.flagCount);
-              const hasAnyFlags = day.flagTypes && day.flagTypes.length > 0;
-              const tooltip = hasAnyFlags
-                ? `${day.dateStr}: ${day.flagTypes.join(' ')}`
-                : `${day.dateStr}: normal`;
+              const colorClass = getCalendarSquareColorClass(day);
+              const tooltip = calendarSquareTooltip(day);
               return `<div class="calendar-square ${colorClass}" data-tooltip="${tooltip}" title="${tooltip}"><span class="calendar-square-day">${day.day}</span></div>`;
             }).join('')}
           </div>
@@ -724,24 +806,31 @@ function renderCalendarHeatmapHeader() {
       <h3 class="calendar-heatmap-title">Sleep Quality history</h3>
       <div class="calendar-heatmap-legend calendar-heatmap-legend--compact">
         <div class="legend-colors-row">
-          <span class="legend-label">normal</span>
+          <span class="legend-label">need data</span>
+          <div class="legend-colors">
+            <div class="legend-square flag-insufficient" title="Fewer than 7 prior nights"></div>
+          </div>
+          <span class="legend-divider">·</span>
+          <span class="legend-label">good</span>
           <div class="legend-colors">
             <div class="legend-square flag-none"></div>
-            <div class="legend-square flag-one"></div>
-            <div class="legend-square flag-two"></div>
-            <div class="legend-square flag-three-plus"></div>
           </div>
-          <span class="legend-label">worse</span>
+          <span class="legend-label">→</span>
+          <div class="legend-colors">
+            <div class="legend-square flag-one" title="Slightly"></div>
+            <div class="legend-square flag-two" title="Moderately"></div>
+            <div class="legend-square flag-three-plus" title="Severe"></div>
+          </div>
+          <span class="legend-label">off pattern</span>
         </div>
         <span class="legend-divider">·</span>
         <div class="legend-meaning legend-meaning--inline">
-          <span class="legend-meaning-item">🛌 bed late</span>
-          <span class="legend-meaning-item">😴 asleep late</span>
-          <span class="legend-meaning-item">⌛ short</span>
-          <span class="legend-meaning-item">🌅 wake deviation</span>
-          <span class="legend-meaning-item">🧩 fragmentation</span>
+          <span class="legend-meaning-item">😴 asleep late vs avg</span>
+          <span class="legend-meaning-item">⌛ shorter duration vs avg</span>
+          <span class="legend-meaning-item">🌅 wake vs avg</span>
+          <span class="legend-meaning-item">🧩 WASO</span>
         </div>
-        <span class="legend-explanation legend-explanation--inline">(vs 7-day avg; bed/asleep/duration 20+ min, wake 30+ min; 🌅 🧩 display only)</span>
+        <span class="legend-explanation legend-explanation--inline">(cell color from worst of 😴 ⌛ 🧩; 🌅 icon only; see Quality page for bands)</span>
       </div>
     </div>
   `;
@@ -1207,7 +1296,6 @@ function renderTimelineLegendControls() {
           <span class="nap">nap</span>
           <span class="bed">bed</span>
           <span class="alarm">alarm</span>
-          <span class="sick">sick</span>
           <span class="bath">bathroom</span>
           <span class="up">get up</span>
         </div>
@@ -1252,6 +1340,45 @@ function toggleFlags(show) {
   document.querySelectorAll('.deviation-warnings').forEach(warnings => {
     warnings.classList.toggle('hidden', !show);
   });
+}
+
+let deviationFlagChipListenersBound = false;
+
+function onDeviationFlagDocumentClick(e) {
+  const chip = e.target.closest('.deviation-flag-chip');
+  if (chip) {
+    const wasOpen = chip.classList.contains('is-expanded');
+    document.querySelectorAll('.deviation-flag-chip.is-expanded').forEach(c => {
+      c.classList.remove('is-expanded');
+      c.setAttribute('aria-expanded', 'false');
+    });
+    if (!wasOpen) {
+      chip.classList.add('is-expanded');
+      chip.setAttribute('aria-expanded', 'true');
+    }
+    return;
+  }
+  document.querySelectorAll('.deviation-flag-chip.is-expanded').forEach(c => {
+    c.classList.remove('is-expanded');
+    c.setAttribute('aria-expanded', 'false');
+  });
+}
+
+function onDeviationFlagEscape(e) {
+  if (e.key !== 'Escape') return;
+  document.querySelectorAll('.deviation-flag-chip.is-expanded').forEach(c => {
+    c.classList.remove('is-expanded');
+    c.setAttribute('aria-expanded', 'false');
+  });
+}
+
+/** Tap/click to expand chips; click outside or Escape closes. Safe to call multiple times. */
+function initDeviationFlagChips() {
+  if (deviationFlagChipListenersBound) return;
+  if (typeof document === 'undefined') return;
+  deviationFlagChipListenersBound = true;
+  document.addEventListener('click', onDeviationFlagDocumentClick);
+  document.addEventListener('keydown', onDeviationFlagEscape);
 }
 
 // Toggle week collapse/expand
@@ -1304,3 +1431,5 @@ if (daysContainer) {
       daysContainer.innerHTML = '<p>Error loading data</p>';
     });
 }
+
+initDeviationFlagChips();

--- a/dashboard.js
+++ b/dashboard.js
@@ -484,6 +484,7 @@ if (dashboardContainer) {
   fetch('sleep-data.json').then(r => r.json())
     .then((sleepData) => {
       dashboardContainer.innerHTML = renderDashboardContent(sleepData.days);
+      if (typeof initDeviationFlagChips === 'function') initDeviationFlagChips();
       renderDashboard7DayGraphs(sleepData.days);
       bindDashboardResponsiveRerender(sleepData.days);
 

--- a/math-tests.js
+++ b/math-tests.js
@@ -79,8 +79,7 @@ function runTests() {
   const interruptionsDay = {
     sleepStart: '23:00',
     sleepEnd: '07:00',
-    alarm: ['01:00', '04:00'],
-    sick: ['06:00']
+    alarm: ['01:00', '04:00']
   };
   expectEqual(u.calculateLongestUninterrupted(interruptionsDay), 180, 'longest uninterrupted span');
 
@@ -142,12 +141,10 @@ function runTests() {
       } else {
         passed += 1;
       }
-      if (Object.prototype.hasOwnProperty.call(d, 'fragmentation') && d.fragmentation != null && d.fragmentation !== '') {
-        if (u.normalizeFragmentationLevel(d) === null) {
-          failures.push(`dataset invariant day ${idx} (${d.date}): fragmentation must be mild, moderate, or severe`);
-        } else {
-          passed += 1;
-        }
+      if (typeof d.WASO !== 'number' || !Number.isFinite(d.WASO) || d.WASO < 0 || d.WASO !== Math.floor(d.WASO)) {
+        failures.push(`dataset invariant day ${idx} (${d.date}): WASO must be a non-negative integer`);
+      } else {
+        passed += 1;
       }
     });
   }

--- a/quality.html
+++ b/quality.html
@@ -8,9 +8,19 @@
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16.png">
 </head>
-<body>
+<body class="quality-page">
   <div id="nav-container"></div>
   <div class="container">
+    <section class="quality-variation-guide" aria-labelledby="quality-variation-heading">
+      <h2 id="quality-variation-heading">How strong is a daily flag?</h2>
+      <p> The flag color is how far that measure drifted from your <strong>previous seven logged nights</strong>. (Fewer than 7 prior nights in the log will show an insufficient-data message.)</p>
+      <ul>
+        <li><span class="quality-swatch quality-swatch--slight" aria-hidden="true"></span> <span><strong>Slightly</strong> off pattern.</span></li>
+        <li><span class="quality-swatch quality-swatch--moderate" aria-hidden="true"></span> <span><strong>Moderately</strong> off pattern.</span></li>
+        <li><span class="quality-swatch quality-swatch--severe" aria-hidden="true"></span> <span><strong>Severely</strong> off pattern.</span></li>
+      </ul>
+      <strong>😴 Asleep</strong> is only flagged when you fell asleep <em>later</em> than your baseline; falling asleep earlier is not flagged. <strong>⌛ Duration</strong> uses the <em>worse</em> of two checks (not added together): shorter than your recent average, <em>or</em> absolute short sleep—under 6 hours (slight), under 5 hours (moderate), under 4 hours (severe)—based on total sleep including naps. <strong>🌅 Wake</strong> compares earlier or later than the baseline. <strong>🧩 WASO</strong> (wake after sleep onset) counts wake episodes longer than 20 minutes: 1 → slight, 2 → moderate, 3 or more → severe. On the <strong>history calendar</strong>, the cell color is the worst of those severities among asleep, duration, and WASO.</p>
+    </section>
     <div id="quality-container"></div>
   </div>
 

--- a/scripts/new-day.js
+++ b/scripts/new-day.js
@@ -33,8 +33,8 @@ function templateFromPrevious(prev) {
       sleepEnd: '7:00',
       bathroom: [],
       alarm: [],
-      sick: [],
-      nap: null
+      nap: null,
+      WASO: 0
     };
   }
   return {
@@ -43,8 +43,8 @@ function templateFromPrevious(prev) {
     sleepEnd: prev.sleepEnd,
     bathroom: [...(prev.bathroom || [])],
     alarm: [...(prev.alarm || [])],
-    sick: [],
-    nap: null
+    nap: null,
+    WASO: 0
   };
 }
 

--- a/scripts/report-duration-flag-impact.js
+++ b/scripts/report-duration-flag-impact.js
@@ -1,0 +1,204 @@
+/**
+ * One-off style report: compare duration + calendar severity before vs after
+ * absolute short-sleep thresholds (matches daily.js logic).
+ * Run: node scripts/report-duration-flag-impact.js
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const LOOKBACK = 7;
+const DAY_MINUTES = 1440;
+const BLEND_ALPHA = 0.75;
+const ABS_SLIGHT = 360;
+const ABS_MOD = 300;
+const ABS_SEV = 240;
+
+function timeToMinutes(time) {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+function durationMinutes(startMinutes, endMinutes) {
+  return endMinutes >= startMinutes ? endMinutes - startMinutes : endMinutes + 1440 - startMinutes;
+}
+
+function calculateTotalSleep(day) {
+  const sleepStart = timeToMinutes(day.sleepStart);
+  const sleepEnd = timeToMinutes(day.sleepEnd);
+  let total = durationMinutes(sleepStart, sleepEnd);
+  if (day.nap && day.nap.start && day.nap.end) {
+    total += durationMinutes(timeToMinutes(day.nap.start), timeToMinutes(day.nap.end));
+  }
+  return total;
+}
+
+function normalizeTimeForAveraging(minutes) {
+  if (minutes < 720) return minutes + 1440;
+  return minutes;
+}
+
+function normalizeWakeTimeForAveraging(sleepStartMinutes, wakeMinutes) {
+  if (wakeMinutes < sleepStartMinutes) {
+    return wakeMinutes + 1440;
+  }
+  if (sleepStartMinutes < 360 && wakeMinutes >= 600) {
+    return wakeMinutes + 1440;
+  }
+  return normalizeTimeForAveraging(wakeMinutes);
+}
+
+function blendedVariationPercent(diffMinutes, avgSleepDurationMinutes) {
+  const sleepBase = Math.max(avgSleepDurationMinutes, 1);
+  const pctSleep = (diffMinutes / sleepBase) * 100;
+  const pctDay = (diffMinutes / DAY_MINUTES) * 100;
+  return BLEND_ALPHA * pctSleep + (1 - BLEND_ALPHA) * pctDay;
+}
+
+function severityFromBlendedPercent(p) {
+  if (p < 5) return null;
+  if (p < 10) return 'slight';
+  if (p < 19) return 'moderate';
+  return 'severe';
+}
+
+const RANK = { slight: 1, moderate: 2, severe: 3 };
+
+function maxSeverity(a, b) {
+  if (!a) return b || null;
+  if (!b) return a;
+  return RANK[a] >= RANK[b] ? a : b;
+}
+
+function severityFromAbsoluteTotalSleepMinutes(totalMinutes) {
+  if (totalMinutes >= ABS_SLIGHT) return null;
+  if (totalMinutes < ABS_SEV) return 'severe';
+  if (totalMinutes < ABS_MOD) return 'moderate';
+  return 'slight';
+}
+
+function normalizeFragmentationLevel(day) {
+  const n = day && day.WASO;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return null;
+  const w = Math.floor(n);
+  if (w < 1) return null;
+  if (w === 1) return 'mild';
+  if (w === 2) return 'moderate';
+  return 'severe';
+}
+
+function wasoQualitySeverity(day) {
+  const frag = normalizeFragmentationLevel(day);
+  if (!frag) return null;
+  if (frag === 'mild') return 'slight';
+  if (frag === 'moderate') return 'moderate';
+  return 'severe';
+}
+
+function calculateRecentAverages(days, currentIndex) {
+  const startIndex = Math.max(0, currentIndex + 1);
+  const endIndex = Math.min(days.length, currentIndex + 1 + LOOKBACK);
+  const recentDays = days.slice(startIndex, endIndex);
+  if (recentDays.length < LOOKBACK) return { insufficient: true };
+
+  let fellAsleepTimeSum = 0;
+  let wakeTimeSum = 0;
+  let sleepDurationSum = 0;
+  recentDays.forEach((day) => {
+    const fellAsleepTime = timeToMinutes(day.sleepStart);
+    fellAsleepTimeSum += normalizeTimeForAveraging(fellAsleepTime);
+    const wakeTime = timeToMinutes(day.sleepEnd);
+    wakeTimeSum += normalizeWakeTimeForAveraging(fellAsleepTime, wakeTime);
+    sleepDurationSum += calculateTotalSleep(day);
+  });
+
+  return {
+    insufficient: false,
+    avgFellAsleepTime: fellAsleepTimeSum / recentDays.length,
+    avgWakeTime: wakeTimeSum / recentDays.length,
+    avgSleepDuration: sleepDurationSum / recentDays.length
+  };
+}
+
+function analyzeDay(day, ra, durationMode) {
+  const avgSleep = ra.avgSleepDuration;
+  const fellAsleepTime = timeToMinutes(day.sleepStart);
+  const normalizedFellAsleep = normalizeTimeForAveraging(fellAsleepTime);
+  const asleepLaterThanAvg = normalizedFellAsleep > ra.avgFellAsleepTime;
+  const asleepDiff = asleepLaterThanAvg ? normalizedFellAsleep - ra.avgFellAsleepTime : 0;
+  const asleepSeverity = asleepLaterThanAvg
+    ? severityFromBlendedPercent(blendedVariationPercent(asleepDiff, avgSleep))
+    : null;
+
+  const sleepDuration = calculateTotalSleep(day);
+  const durationShorterThanAvg = sleepDuration < ra.avgSleepDuration;
+  const durDiff = durationShorterThanAvg ? ra.avgSleepDuration - sleepDuration : 0;
+  const relativeDurationSeverity = durationShorterThanAvg
+    ? severityFromBlendedPercent(blendedVariationPercent(durDiff, avgSleep))
+    : null;
+  const absoluteDurationSeverity = severityFromAbsoluteTotalSleepMinutes(sleepDuration);
+  const durationSeverity =
+    durationMode === 'relative-only'
+      ? relativeDurationSeverity
+      : maxSeverity(relativeDurationSeverity, absoluteDurationSeverity);
+
+  return { asleepSeverity, durationSeverity, relativeDurationSeverity, absoluteDurationSeverity };
+}
+
+function worstCalendarSeverity(day, ra, durationMode) {
+  const t = analyzeDay(day, ra, durationMode);
+  let worst = maxSeverity(t.asleepSeverity, t.durationSeverity);
+  worst = maxSeverity(worst, wasoQualitySeverity(day));
+  return worst || 'none';
+}
+
+const dataPath = path.join(__dirname, '..', 'sleep-data.json');
+const days = JSON.parse(fs.readFileSync(dataPath, 'utf8')).days;
+
+let newDurationFlagDays = 0;
+let durationOnlySeverityChanged = 0;
+let calendarCellChanged = 0;
+const durationChangeDates = [];
+
+for (let i = 0; i < days.length; i++) {
+  const ra = calculateRecentAverages(days, i);
+  if (ra.insufficient) continue;
+
+  const day = days[i];
+  const oldT = analyzeDay(day, ra, 'relative-only');
+  const newT = analyzeDay(day, ra, 'combined');
+
+  const oldDur = oldT.durationSeverity;
+  const newDur = newT.durationSeverity;
+  if (oldDur !== newDur) {
+    durationOnlySeverityChanged += 1;
+    durationChangeDates.push({
+      date: day.date,
+      old: oldDur || '—',
+      new: newDur || '—',
+      totalH: (calculateTotalSleep(day) / 60).toFixed(2),
+      abs: newT.absoluteDurationSeverity || '—',
+      rel: newT.relativeDurationSeverity || '—'
+    });
+  }
+
+  if (!oldDur && newDur) {
+    newDurationFlagDays += 1;
+  }
+
+  const oldCell = worstCalendarSeverity(day, ra, 'relative-only');
+  const newCell = worstCalendarSeverity(day, ra, 'combined');
+  if (oldCell !== newCell) {
+    calendarCellChanged += 1;
+  }
+}
+
+const withLookback = days.reduce((n, _, i) => n + (calculateRecentAverages(days, i).insufficient ? 0 : 1), 0);
+
+console.log(JSON.stringify({
+  daysWithSevenNightLookback: withLookback,
+  newDurationFlagDays_noRelativeButNowFlagged: newDurationFlagDays,
+  durationSeverityChangedDays_oldVsNew: durationOnlySeverityChanged,
+  calendarCellWorstSeverityChangedDays: calendarCellChanged,
+  sampleDurationChanges: durationChangeDates.slice(0, 20)
+}, null, 2));

--- a/sleep-data.json
+++ b/sleep-data.json
@@ -11,8 +11,8 @@
       "alarm": [
         "7:05"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 2
     },
     {
       "date": "3/23",
@@ -26,8 +26,8 @@
       "alarm": [
         "7:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/22",
@@ -38,9 +38,8 @@
         "7:20"
       ],
       "alarm": [],
-      "sick": [],
       "nap": null,
-      "fragmentation": "severe"
+      "WASO": 5
     },
     {
       "date": "3/21",
@@ -53,8 +52,8 @@
       "alarm": [
         "7:02"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/20",
@@ -67,8 +66,8 @@
       "alarm": [
         "7:03"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/19",
@@ -81,8 +80,8 @@
       "alarm": [
         "7:05"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/18",
@@ -95,8 +94,8 @@
       "alarm": [
         "7:10"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/17",
@@ -111,11 +110,11 @@
         "7:15",
         "7:54"
       ],
-      "sick": [],
       "nap": {
         "start": "18:40",
         "end": "19:50"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "3/16",
@@ -126,8 +125,8 @@
         "6:10"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/15",
@@ -138,8 +137,8 @@
         "2:25"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/14",
@@ -150,8 +149,8 @@
         "3:30"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/13",
@@ -164,11 +163,11 @@
       "alarm": [
         "7:00"
       ],
-      "sick": [],
       "nap": {
         "start": "17:10",
         "end": "18:45"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "3/12",
@@ -181,8 +180,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/11",
@@ -195,11 +194,11 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
       "nap": {
         "start": "18:15",
         "end": "19:15"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "3/10",
@@ -212,8 +211,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/9",
@@ -226,8 +225,8 @@
       "alarm": [
         "6:55"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/8",
@@ -240,8 +239,8 @@
       "alarm": [
         "7:05"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/7",
@@ -252,8 +251,8 @@
       "alarm": [
         "7:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/6",
@@ -266,8 +265,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/5",
@@ -278,8 +277,8 @@
       "alarm": [
         "6:46"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/4",
@@ -292,11 +291,11 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
       "nap": {
         "start": "18:00",
         "end": "19:10"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "3/3",
@@ -309,8 +308,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/2",
@@ -323,8 +322,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "3/1",
@@ -337,8 +336,8 @@
       "alarm": [
         "7:05"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/28",
@@ -349,11 +348,11 @@
       "alarm": [
         "7:15"
       ],
-      "sick": [],
       "nap": {
         "start": "15:00",
         "end": "16:30"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/27",
@@ -366,11 +365,11 @@
       "alarm": [
         "7:40"
       ],
-      "sick": [],
       "nap": {
         "start": "15:30",
         "end": "20:30"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/26",
@@ -383,8 +382,8 @@
       "alarm": [
         "7:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/25",
@@ -397,8 +396,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/24",
@@ -411,8 +410,8 @@
       "alarm": [
         "6:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/23",
@@ -425,8 +424,8 @@
       "alarm": [
         "7:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/22",
@@ -441,11 +440,11 @@
         "7:15",
         "7:25"
       ],
-      "sick": [],
       "nap": {
         "start": "12:10",
         "end": "14:00"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/21",
@@ -458,8 +457,8 @@
       "alarm": [
         "7:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/20",
@@ -472,8 +471,8 @@
       "alarm": [
         "6:40"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/19",
@@ -484,11 +483,11 @@
       "alarm": [
         "7:10"
       ],
-      "sick": [],
       "nap": {
         "start": "18:10",
         "end": "18:50"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/18",
@@ -499,8 +498,8 @@
       "alarm": [
         "7:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/17",
@@ -509,8 +508,8 @@
       "sleepEnd": "7:40",
       "bathroom": [],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/16",
@@ -526,8 +525,8 @@
         "7:30",
         "08:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/15",
@@ -541,8 +540,8 @@
       "alarm": [
         "7:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/14",
@@ -555,8 +554,8 @@
       "alarm": [
         "07:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/13",
@@ -567,8 +566,8 @@
       "alarm": [
         "7:20"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/12",
@@ -581,8 +580,8 @@
       "alarm": [
         "07:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/11",
@@ -595,11 +594,11 @@
       "alarm": [
         "07:45"
       ],
-      "sick": [],
       "nap": {
         "start": "16:00",
         "end": "16:45"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/10",
@@ -612,8 +611,8 @@
       "alarm": [
         "08:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/9",
@@ -624,8 +623,8 @@
       "alarm": [
         "07:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/8",
@@ -638,11 +637,11 @@
       "alarm": [
         "08:30"
       ],
-      "sick": [],
       "nap": {
         "start": "15:20",
         "end": "16:30"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/7",
@@ -656,11 +655,11 @@
         "08:10",
         "08:30"
       ],
-      "sick": [],
       "nap": {
         "start": "18:10",
         "end": "19:00"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "2/6",
@@ -669,8 +668,8 @@
       "sleepEnd": "07:50",
       "bathroom": [],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/5",
@@ -683,8 +682,8 @@
       "alarm": [
         "08:40"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/4",
@@ -698,8 +697,8 @@
       "alarm": [
         "08:40"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/3",
@@ -712,8 +711,8 @@
       "alarm": [
         "08:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/2",
@@ -726,8 +725,8 @@
       "alarm": [
         "09:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "2/1",
@@ -738,8 +737,8 @@
         "06:00"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/31",
@@ -748,14 +747,11 @@
       "sleepEnd": "09:30",
       "bathroom": [],
       "alarm": [],
-      "sick": [
-        "04:00",
-        "04:30"
-      ],
       "nap": {
         "start": "17:00",
         "end": "17:45"
-      }
+      },
+      "WASO": 2
     },
     {
       "date": "1/30",
@@ -764,8 +760,8 @@
       "sleepEnd": "08:50",
       "bathroom": [],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/29",
@@ -774,8 +770,8 @@
       "sleepEnd": "09:00",
       "bathroom": [],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/28",
@@ -788,8 +784,8 @@
       "alarm": [
         "09:20"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/27",
@@ -802,8 +798,8 @@
       "alarm": [
         "09:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/26",
@@ -816,8 +812,8 @@
       "alarm": [
         "09:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/25",
@@ -828,8 +824,8 @@
         "06:30"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/24",
@@ -840,11 +836,11 @@
         "04:30"
       ],
       "alarm": [],
-      "sick": [],
       "nap": {
         "start": "17:00",
         "end": "17:40"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "1/23",
@@ -858,8 +854,8 @@
         "09:15",
         "09:45"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/22",
@@ -873,8 +869,8 @@
         "09:00",
         "09:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/21",
@@ -888,8 +884,8 @@
         "09:30",
         "10:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/20",
@@ -903,8 +899,8 @@
         "09:30",
         "10:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/19",
@@ -921,8 +917,8 @@
         "09:40",
         "10:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/18",
@@ -933,8 +929,8 @@
         "04:50"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/17",
@@ -943,8 +939,8 @@
       "sleepEnd": "11:50",
       "bathroom": [],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/16",
@@ -958,8 +954,8 @@
         "09:00",
         "10:00"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/15",
@@ -973,8 +969,8 @@
         "09:00",
         "09:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/14",
@@ -986,8 +982,8 @@
         "09:30",
         "10:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/13",
@@ -998,11 +994,11 @@
       "alarm": [
         "08:30"
       ],
-      "sick": [],
       "nap": {
         "start": "18:15",
         "end": "19:00"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "1/12",
@@ -1013,8 +1009,8 @@
         "07:00"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/11",
@@ -1025,14 +1021,8 @@
         "06:45"
       ],
       "alarm": [],
-      "sick": [
-        "02:00",
-        "02:30",
-        "03:00",
-        "03:30",
-        "05:00"
-      ],
-      "nap": null
+      "nap": null,
+      "WASO": 5
     },
     {
       "date": "1/10",
@@ -1043,8 +1033,8 @@
         "10:10"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/9",
@@ -1055,8 +1045,8 @@
       "alarm": [
         "09:50"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/8",
@@ -1070,8 +1060,8 @@
         "09:50",
         "10:20"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/7",
@@ -1086,8 +1076,8 @@
         "09:00",
         "09:15"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/6",
@@ -1103,8 +1093,8 @@
         "10:45",
         "11:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/5",
@@ -1117,8 +1107,8 @@
         "10:00",
         "10:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/4",
@@ -1129,8 +1119,8 @@
         "10:20"
       ],
       "alarm": [],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/3",
@@ -1147,8 +1137,8 @@
         "12:30",
         "13:30"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     },
     {
       "date": "1/2",
@@ -1161,11 +1151,11 @@
       "alarm": [
         "11:15"
       ],
-      "sick": [],
       "nap": {
         "start": "19:30",
         "end": "20:15"
-      }
+      },
+      "WASO": 0
     },
     {
       "date": "1/1",
@@ -1179,8 +1169,8 @@
         "10:00",
         "12:20"
       ],
-      "sick": [],
-      "nap": null
+      "nap": null,
+      "WASO": 0
     }
   ]
 }

--- a/sleep-quality-palettes.html
+++ b/sleep-quality-palettes.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sleep quality palettes (6-step)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,600;1,9..40,400&family=Fraunces:opsz,wght@9..144,600&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg: #0f1219;
+      --card: #181c27;
+      --text: #e8eaef;
+      --muted: #8b92a8;
+      --border: #2a3142;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "DM Sans", system-ui, sans-serif;
+      font-size: 15px;
+      line-height: 1.5;
+      padding: 2rem 1.25rem 3rem;
+    }
+    h1 {
+      font-family: Fraunces, Georgia, serif;
+      font-weight: 600;
+      font-size: clamp(1.5rem, 4vw, 2rem);
+      margin: 0 0 0.35rem;
+      letter-spacing: -0.02em;
+    }
+    .lede {
+      color: var(--muted);
+      max-width: 42rem;
+      margin: 0 0 2rem;
+    }
+    .grid {
+      display: grid;
+      gap: 1.5rem;
+      max-width: 52rem;
+    }
+    .scheme {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.1rem 1.25rem 1.25rem;
+    }
+    .scheme h2 {
+      margin: 0 0 0.65rem;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text);
+    }
+    .scheme p.desc {
+      margin: 0 0 1rem;
+      font-size: 0.875rem;
+      color: var(--muted);
+    }
+    .hex-list {
+      margin: 0 0 1rem;
+      font-size: 0.8125rem;
+      color: #a8b0c4;
+      font-variant-numeric: tabular-nums;
+      word-break: break-all;
+    }
+    .bar {
+      display: flex;
+      height: 3rem;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06);
+    }
+    .bar span {
+      flex: 1;
+      min-width: 0;
+    }
+    .labels {
+      display: flex;
+      margin-top: 0.5rem;
+      font-size: 0.68rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .labels span {
+      flex: 1;
+      text-align: center;
+    }
+    .note {
+      margin-top: 2rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.8125rem;
+      color: var(--muted);
+      max-width: 42rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Sleep quality palettes</h1>
+  <p class="lede">
+    Two six-step spectra (best → worst), hard edges between tiers. Primary follows the Traffic + Earth hybrid: a stronger top green, your midpoint green, a yellow-green step into amber, then honey and wine. Alternate keeps the same shape (cool “rest” highs → warm “stress” lows) with teal and sage instead of grass green.
+  </p>
+
+  <div class="grid">
+    <section class="scheme">
+      <h2>Primary — Traffic + Earth hybrid (6 steps)</h2>
+      <p class="desc">
+        <strong>Excellent</strong> is a bit cleaner and brighter than the midpoint green without going Traffic-neon.
+        <strong>Great</strong> stays the Traffic / Earth midpoint (<code style="color:#c4c9d4">#318f2d</code>).
+        <strong>Good</strong> bridges green and Traffic amber. Then Traffic amber, Earth honey, Earth wine (rust is folded into that last step’s family by ending on wine).
+      </p>
+      <p class="hex-list">
+        #41b746 · #318f2d · #b0aa28 · #ca8a04 · #b45309 · #7f1d1d
+      </p>
+      <div class="bar" aria-hidden="true">
+        <span style="background:#41b746"></span>
+        <span style="background:#318f2d"></span>
+        <span style="background:#b0aa28"></span>
+        <span style="background:#ca8a04"></span>
+        <span style="background:#b45309"></span>
+        <span style="background:#7f1d1d"></span>
+      </div>
+      <div class="labels">
+        <span>Excellent</span><span>Great</span><span>Good</span><span>OK</span><span>Poor</span><span>Bad</span>
+      </div>
+    </section>
+
+    <section class="scheme">
+      <h2>Alternate — same philosophy, cool highs</h2>
+      <p class="desc">
+        Same six roles: two cool “good sleep” greens/teals, one mixed bridge into warm gold, then ochre, terracotta, and deep burgundy. For people who prefer blue-green over grass green; still natural and stepped, not rainbow.
+      </p>
+      <p class="hex-list">
+        #3db0a4 · #2f8f82 · #8fb88a · #d4a03d · #c0643a · #6c2528
+      </p>
+      <div class="bar" aria-hidden="true">
+        <span style="background:#3db0a4"></span>
+        <span style="background:#2f8f82"></span>
+        <span style="background:#8fb88a"></span>
+        <span style="background:#d4a03d"></span>
+        <span style="background:#c0643a"></span>
+        <span style="background:#6c2528"></span>
+      </div>
+      <div class="labels">
+        <span>Excellent</span><span>Great</span><span>Good</span><span>OK</span><span>Poor</span><span>Bad</span>
+      </div>
+    </section>
+  </div>
+
+  <p class="note">
+    Six equal segments per bar. Map your quality buckets to these stops in order, or split/merge tiers in your app if you use fewer than six labels.
+  </p>
+</body>
+</html>

--- a/sleep-utils.js
+++ b/sleep-utils.js
@@ -69,12 +69,18 @@ function calculateTotalSleep(day) {
   return total;
 }
 
-const FRAGMENTATION_LEVELS = new Set(['mild', 'moderate', 'severe']);
-
-/** Per-night fragmentation for JSON field `fragmentation`; null if absent or invalid. */
+/**
+ * Stripe level from JSON `WASO` (wake-after-sleep-onset episode count): 1 → mild, 2 → moderate, 3+ → severe.
+ * Returns null when WASO is 0, missing, or invalid.
+ */
 function normalizeFragmentationLevel(day) {
-  const v = day && day.fragmentation;
-  return typeof v === 'string' && FRAGMENTATION_LEVELS.has(v) ? v : null;
+  const n = day && day.WASO;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return null;
+  const w = Math.floor(n);
+  if (w < 1) return null;
+  if (w === 1) return 'mild';
+  if (w === 2) return 'moderate';
+  return 'severe';
 }
 
 /**
@@ -186,7 +192,7 @@ function normalizeTimeForYAxis(minutes) {
   return minutes;
 }
 
-// Calculate longest uninterrupted sleep (ignoring bathroom, including alarms and sick)
+// Calculate longest uninterrupted sleep (ignoring bathroom; alarms count as interruptions)
 function calculateLongestUninterrupted(day) {
   const sleepStart = timeToMinutes(day.sleepStart);
   const sleepEnd = timeToMinutes(day.sleepEnd);
@@ -205,12 +211,7 @@ function calculateLongestUninterrupted(day) {
     .map(normalizeInterruption)
     .filter(m => m >= sleepStart && m <= normalizedSleepEnd);
 
-  const sickInterruptions = (day.sick || [])
-    .map(timeToMinutes)
-    .map(normalizeInterruption)
-    .filter(m => m >= sleepStart && m <= normalizedSleepEnd);
-
-  const interruptions = [...alarmInterruptions, ...sickInterruptions];
+  const interruptions = [...alarmInterruptions];
   interruptions.sort((a, b) => a - b);
 
   if (interruptions.length === 0) {

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,6 @@
   --color-nap: #c4b5fd;
   --color-bed: #60a5fa;
   --color-alarm: #c2410c;
-  --color-sick: #ec4899;
   --color-bath: #fbbf24;
   --color-up: #34d399;
   --color-sunrise: #f59e0b;
@@ -31,6 +30,8 @@
   --previous-day-overlay: rgba(0, 0, 0, 0.3);
   --weekend-bg: rgba(96, 165, 250, 0.15);
   --weekend-border: rgba(96, 165, 250, 0.4);
+  --weekend-lip-width: 6px;
+  --deviation-lip-width: 6px;
   --warning-bg: rgba(251, 191, 36, 0.1);
   --warning-border: rgba(251, 191, 36, 0.4);
   /* Fragmentation deviation strip: moderate between default amber and severe red */
@@ -50,11 +51,16 @@
   --frag-stripe-sev-a: rgba(118, 8, 32, 0.58);
   --frag-stripe-sev-b: rgba(138, 4, 28, 0.48);
 
+  /* Shared quality ramp (daily flags + calendar; matches sleep-quality-palettes) */
+  --quality-slight: #ca8a04;
+  --quality-moderate: #b45309;
+  --quality-severe: #7f1d1d;
   /* Calendar/legend quality-flag colors */
+  --flag-insufficient: #64748b;
   --flag-none: #15803d;
-  --flag-one: #c89f04;
-  --flag-two: #a16207;
-  --flag-three-plus: #991b1b;
+  --flag-one: var(--quality-slight);
+  --flag-two: var(--quality-moderate);
+  --flag-three-plus: var(--quality-severe);
 
   --chart-error-bg: rgba(194, 65, 12, 0.1);
 
@@ -98,7 +104,6 @@
   --color-nap: #6d28d9;
   --color-bed: #1d4ed8;
   --color-alarm: #9a3412;
-  --color-sick: #9d174d;
   --color-bath: #b45309;
   --color-up: #047857;
   --color-sunrise: #b45309;
@@ -115,11 +120,12 @@
   --frag-stripe-sev-a: rgba(205, 55, 90, 0.54);
   --frag-stripe-sev-b: rgba(198, 40, 78, 0.44);
 
-  /* Day mode: darker flag square colours so labels/contrast are easier to read */
+  /* Day mode: darker green for “good” cell; severity ramp unchanged */
   --flag-none: #166534;
-  --flag-one: #a16207;
-  --flag-two: #854d0e;
-  --flag-three-plus: #7f1d1d;
+  --flag-insufficient: #64748b;
+  --flag-one: var(--quality-slight);
+  --flag-two: var(--quality-moderate);
+  --flag-three-plus: var(--quality-severe);
 
   /* Nav app title: darker blue for light mode (softer than icon blue) */
   --nav-app-text-color: #25408a;
@@ -1644,8 +1650,8 @@ body{
 
 .day.weekend{
   background: transparent;
-  border-left: 2px solid var(--weekend-border);
-  padding-left: calc(var(--space-3) - 2px);
+  border-left: var(--weekend-lip-width) solid var(--weekend-border);
+  padding-left: calc(var(--space-3) - var(--weekend-lip-width));
 }
 
 .week-days .day:last-child {
@@ -1691,25 +1697,143 @@ body{
 
 .deviation-warning{
   font-size: 11px;
-  color: var(--color-bath);
-  opacity: 0.9;
+  color: var(--text);
+  opacity: 0.95;
   padding: 4px 8px;
   background: var(--warning-bg);
   border-radius: 6px;
-  border-left: 2px solid var(--warning-border);
+  border-left: var(--deviation-lip-width) solid var(--warning-border);
   width: fit-content;
 }
 
-.deviation-warning--frag-moderate{
-  color: var(--frag-dev-mod-text);
-  background: var(--frag-dev-mod-bg);
-  border-left-color: var(--frag-dev-mod-border);
+.deviation-warning--slight{
+  border-left-color: var(--quality-slight);
+  background: rgba(202, 138, 4, 0.14);
 }
 
-.deviation-warning--frag-severe{
-  color: var(--frag-dev-sev-text);
-  background: var(--frag-dev-sev-bg);
-  border-left-color: var(--frag-dev-sev-border);
+.deviation-warning--moderate{
+  border-left-color: var(--quality-moderate);
+  background: rgba(180, 83, 9, 0.14);
+}
+
+.deviation-warning--severe{
+  border-left-color: var(--quality-severe);
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.deviation-warning--insufficient{
+  border-left-color: var(--flag-insufficient);
+  background: rgba(100, 116, 139, 0.2);
+  color: var(--text);
+}
+
+/* Daily / dashboard: compact flag chips (icon + severity color; hover or tap expands copy) */
+.deviation-warnings--chips{
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.deviation-flag-chip{
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 0;
+  padding: 4px 6px 4px 5px;
+  min-height: 34px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.96);
+  touch-action: manipulation;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.22);
+  transition: box-shadow 0.15s ease, transform 0.12s ease;
+  vertical-align: middle;
+}
+
+.deviation-flag-chip strong{
+  font-weight: 700;
+  color: inherit;
+}
+
+.deviation-flag-chip:active{
+  transform: scale(0.98);
+}
+
+.deviation-flag-chip:focus-visible{
+  outline: 2px solid var(--color-hover-blue);
+  outline-offset: 2px;
+}
+
+.deviation-flag-chip-icon{
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+.deviation-flag-chip-text{
+  display: inline-block;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: middle;
+  transition: max-width 0.24s ease, opacity 0.18s ease, padding 0.2s ease;
+  padding: 0;
+  text-align: left;
+  font-variant-numeric: tabular-nums;
+}
+
+.deviation-flag-chip.is-expanded{
+  z-index: 8;
+}
+
+/* Keep nowrap while max-width animates — avoids a 1→2 line flash that shifts layout */
+.deviation-flag-chip.is-expanded .deviation-flag-chip-text{
+  max-width: min(320px, 92vw);
+  opacity: 1;
+  padding-left: 8px;
+}
+
+@media (hover: hover) and (pointer: fine){
+  .deviation-flag-chip:hover{
+    z-index: 8;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
+  }
+
+  .deviation-flag-chip:hover .deviation-flag-chip-text,
+  .deviation-flag-chip:focus-visible .deviation-flag-chip-text{
+    max-width: min(320px, 92vw);
+    opacity: 1;
+    padding-left: 8px;
+  }
+}
+
+.deviation-flag-chip--slight{
+  background: var(--quality-slight);
+}
+
+.deviation-flag-chip--moderate{
+  background: var(--quality-moderate);
+}
+
+.deviation-flag-chip--severe{
+  background: var(--quality-severe);
+}
+
+.deviation-flag-chip--insufficient{
+  background: var(--flag-insufficient);
+  color: rgba(255, 255, 255, 0.95);
 }
 
 .day-stats{
@@ -2008,7 +2132,6 @@ body{
 
 .event.bed{ background: var(--color-bed); }
 .event.alarm{ background: var(--color-alarm); }
-.event.sick{ background: var(--color-sick); }
 .event.bath{ background: var(--color-bath); }
 .event.up{ background: var(--color-up); }
 
@@ -2038,7 +2161,6 @@ body{
 .legend .nap{ color: var(--color-nap); }
 .legend .bed{ color: var(--color-bed); }
 .legend .alarm{ color: var(--color-alarm); }
-.legend .sick{ color: var(--color-sick); }
 .legend .bath{ color: var(--color-bath); }
 .legend .up{ color: var(--color-up); }
 
@@ -2833,6 +2955,10 @@ svg {
   background: var(--flag-three-plus);
 }
 
+.legend-square.flag-insufficient {
+  background: var(--flag-insufficient);
+}
+
 .calendar-heatmap {
   position: relative;
   overflow-x: auto;
@@ -3090,11 +3216,67 @@ svg {
   background: var(--flag-three-plus);
 }
 
+.calendar-square.flag-insufficient {
+  background: var(--flag-insufficient);
+}
+
 .calendar-square:not(.empty):hover {
   outline: 1px solid rgba(255, 255, 255, 0.5);
   outline-offset: 1px;
   transform: scale(1.2);
   z-index: 10;
+}
+
+/* Sleep Quality page — how daily severity maps to color */
+.quality-page .quality-variation-guide {
+  max-width: 42rem;
+  margin-bottom: var(--space-5);
+  padding: var(--panel-padding);
+  background: var(--panel);
+  border-radius: var(--panel-radius);
+  border: 1px solid var(--panel-border-color);
+  box-shadow: var(--panel-shadow);
+}
+
+.quality-page .quality-variation-guide h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.quality-page .quality-variation-guide ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0.75rem 0 0;
+}
+
+.quality-page .quality-variation-guide li {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 0.5rem;
+}
+
+.quality-swatch {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 0.65rem;
+  border-radius: 3px;
+}
+
+.quality-swatch--slight {
+  background: var(--quality-slight);
+}
+
+.quality-swatch--moderate {
+  background: var(--quality-moderate);
+}
+
+.quality-swatch--severe {
+  background: var(--quality-severe);
+}
+
+.quality-swatch--insufficient {
+  background: var(--flag-insufficient);
 }
 
 /* For first week row of first month, show tooltip below so it's not cut off */


### PR DESCRIPTION
- Updated sleep flag mechanics:
  - Removed "bedtime" deviation (overlap with sleep time; kept data for SOL)
  - WASO now impacts quality
  - Flags now use % deviation as severity multipliers (< 5%: no flag; 5–<10%: slight; 10–<19%: moderate; ≥ 19%: sever)
  - Still tweaking impact values; current color is lowest (most severe) of all flags
- Added WASO to data json
- Added text about sleep quality flags
- Flags are now chips in dailies instead of banners
- Palettes is a temporary UI file