### PR TITLE
About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,85 +10,82 @@
 </head>
 <body>
   <div id="nav-container"></div>
-  <div class="about-deck" id="about-deck">
-    <div class="about-slides-viewport" id="about-slides-viewport">
-    <div class="about-slides" id="about-slides">
-      <!-- Slide 1: Getting started -->
-      <section class="about-slide" aria-label="Getting started">
-        <div class="container about-slide-inner">
-          <h1 class="page-title">Getting started</h1>
-          <p class="about-intro">Use the icons in the bar below to move between pages:</p>
-          <ul class="about-page-list">
-            <li>
-              <span class="about-page-icon" aria-hidden="true">🛌</span>
-              <span class="about-page-name">Dashboard</span>
-              <span class="about-page-desc">Overview with recent and lifetime averages, recent nights, and 7-day time and duration charts.</span>
-            </li>
-            <li>
-              <span class="about-page-icon" aria-hidden="true">✏️</span>
-              <span class="about-page-name">Log</span>
-              <span class="about-page-desc">Add or edit a night: bed, sleep, wake, bathroom and alarm times, nap, and WASO.</span>
-            </li>
-            <li>
-              <span class="about-page-icon" aria-hidden="true">🟩</span>
-              <span class="about-page-name">Quality</span>
-              <span class="about-page-desc">Sleep quality history over time.</span>
-            </li>
-            <li>
-              <span class="about-page-icon" aria-hidden="true">📅</span>
-              <span class="about-page-name">Daily</span>
-              <span class="about-page-desc">Day-by-day timeline of bed, sleep, and get-up times.</span>
-            </li>
-            <li>
-              <span class="about-page-icon" aria-hidden="true">📊</span>
-              <span class="about-page-name">Graphs</span>
-              <span class="about-page-desc">Time and duration charts with trend lines across your data.</span>
-            </li>
-            <li>
-              <span class="about-page-icon" aria-hidden="true">🔢</span>
-              <span class="about-page-name">Stats</span>
-              <span class="about-page-desc">Monthly sleep statistics.</span>
-            </li>
-          </ul>
+  <div class="container container--config">
+    <h1 class="page-title config-page-title">About</h1>
+
+    <h2 class="section-title">Getting started</h2>
+    <p class="about-intro">Use the icons in the bar below to move between pages:</p>
+    <ul class="about-page-list">
+      <li>
+        <span class="about-page-icon" aria-hidden="true">🛌</span>
+        <span class="about-page-name">Dashboard</span>
+        <span class="about-page-desc">Overview with recent and lifetime averages, recent nights, and 7-day time and duration charts.</span>
+      </li>
+      <li>
+        <span class="about-page-icon" aria-hidden="true">✏️</span>
+        <span class="about-page-name">Log</span>
+        <span class="about-page-desc">Add or edit a night: bed, sleep, wake, bathroom and alarm times, nap, and WASO.</span>
+      </li>
+      <li>
+        <span class="about-page-icon" aria-hidden="true">🟩</span>
+        <span class="about-page-name">Quality</span>
+        <span class="about-page-desc">Sleep quality history over time.</span>
+      </li>
+      <li>
+        <span class="about-page-icon" aria-hidden="true">📅</span>
+        <span class="about-page-name">Daily</span>
+        <span class="about-page-desc">Day-by-day timeline of bed, sleep, and get-up times.</span>
+      </li>
+      <li>
+        <span class="about-page-icon" aria-hidden="true">📊</span>
+        <span class="about-page-name">Graphs</span>
+        <span class="about-page-desc">Time and duration charts with trend lines across your data.</span>
+      </li>
+      <li>
+        <span class="about-page-icon" aria-hidden="true">🔢</span>
+        <span class="about-page-name">Stats</span>
+        <span class="about-page-desc">Monthly sleep statistics.</span>
+      </li>
+    </ul>
+
+    <h2 class="section-title" id="remaining-wake-time">Remaining Wake Time</h2>
+    <p class="section-intro">Shows how much time is left in your day before your recommended sleep time. Phases are based on the <strong>percent of wake time remaining</strong>. This is meant to gently guide your pace, not rush you. You can adjust thresholds below or in <a class="content-link" href="config.html#remaining-wake">Settings</a>.</p>
+    <p class="section-intro">The day is divided into three simple phases:</p>
+    <ul class="about-phase-list">
+      <li class="about-phase-item">
+        <span class="about-phase-icon" aria-hidden="true">☀️</span>
+        <div class="about-phase-body">
+          <span class="about-phase-name">Open time</span>
+          <span class="about-phase-range">This is the primary portion of your day, with plenty of runway. The feeling is steady, normal, and no urgency.</span>
         </div>
-      </section>
-      <!-- Slide 2: Remaining Wake Time -->
-      <section class="about-slide" id="remaining-wake-time" aria-label="Remaining Wake Time">
-        <div class="container about-slide-inner">
-          <h2 class="section-title">Remaining Wake Time</h2>
-          <p class="section-intro">Shows how much time is left in your day before your recommended sleep time. Phases are based on the <strong>percent of wake time remaining</strong>. This is meant to gently guide your pace, not rush you. You can adjust thresholds below or in <a class="content-link" href="config.html#remaining-wake">Settings</a>.</p>
-          <p class="section-intro">The day is divided into three simple phases:</p>
-          <ul class="about-phase-list">
-            <li class="about-phase-item">
-              <span class="about-phase-icon" aria-hidden="true">☀️</span>
-              <div class="about-phase-body">
-                <span class="about-phase-name">Open time</span>
-                <span class="about-phase-range">This is the primary portion of your day, with plenty of runway. The feeling is steady, normal, and no urgency.</span>
-              </div>
-            </li>
-            <li class="about-phase-item">
-              <span class="about-phase-icon" aria-hidden="true">🌇</span>
-              <div class="about-phase-body">
-                <span class="about-phase-name">Winding down</span>
-                <span class="about-phase-range">It is not quite time to sleep, but avoid starting heavy or demanding activities. Caffiene is not recommended from this point.</span>
-              </div>
-            </li>
-            <li class="about-phase-item">
-              <span class="about-phase-icon" aria-hidden="true">🛏️</span>
-              <div class="about-phase-body">
-                <span class="about-phase-name">Pre-sleep</span>
-                <span class="about-phase-range">Being preparing for rest. Avoid meals and stimulating activity.</span>
-              </div>
-            </li>
-          </ul>
-          <h3 class="section-title about-rw-thresholds-heading" id="about-remaining-wake-thresholds">Adjust thresholds</h3>
-          <p class="section-intro">Percentages are <strong>your share of wake time left</strong> from your recent 7-day average get-up time to average fell-asleep time—the same window the header clock uses. The times under each slider show roughly when those boundaries fall on a typical day.</p>
-          <div id="about-remaining-wake-mount"></div>
+      </li>
+      <li class="about-phase-item">
+        <span class="about-phase-icon" aria-hidden="true">🌇</span>
+        <div class="about-phase-body">
+          <span class="about-phase-name">Winding down</span>
+          <span class="about-phase-range">It is not quite time to sleep, but avoid starting heavy or demanding activities. Caffiene is not recommended from this point.</span>
         </div>
-      </section>
-    </div>
-    </div>
-    <div class="about-dots" id="about-dots" role="tablist" aria-label="About sections"></div>
+      </li>
+      <li class="about-phase-item">
+        <span class="about-phase-icon" aria-hidden="true">🛏️</span>
+        <div class="about-phase-body">
+          <span class="about-phase-name">Pre-sleep</span>
+          <span class="about-phase-range">Being preparing for rest. Avoid meals and stimulating activity.</span>
+        </div>
+      </li>
+    </ul>
+    <h3 class="section-title about-rw-thresholds-heading" id="about-remaining-wake-thresholds">Adjust thresholds</h3>
+    <p class="section-intro">Percentages are <strong>your share of wake time left</strong> from your recent 7-day average get-up time to average fell-asleep time—the same window the header clock uses. The times under each slider show roughly when those boundaries fall on a typical day.</p>
+    <div id="about-remaining-wake-mount"></div>
+
+    <h2 class="section-title" id="daily-flags">Daily flags</h2>
+    <h3 class="section-title about-daily-flags-subheading">How strong is a daily flag?</h3>
+    <p class="section-intro">The flag color is how far that measure drifted from your <strong>previous seven logged nights</strong>. (Fewer than 7 prior nights in the log will show an insufficient-data message.)</p>
+    <p class="section-intro"><strong>😴 Asleep</strong> is only flagged when you fell asleep <em>later</em> than your baseline; falling asleep earlier is not flagged.</p>
+    <p class="section-intro"><strong>⌛ Duration</strong> uses the <em>worse</em> of two checks (not added together): shorter than your recent average, <em>or</em> absolute short sleep—under 6 hours (slight), under 5 hours (moderate), under 4 hours (severe)—based on total sleep including naps.</p>
+    <p class="section-intro"><strong>🌅 Wake</strong> compares earlier or later than the baseline.</p>
+    <p class="section-intro"><strong>🧩 WASO</strong> (wake after sleep onset) counts wake episodes longer than 20 minutes: 1 → slight, 2 → moderate, 3 or more → severe.</p>
+    <p class="section-intro">On the <strong>history calendar</strong>, the cell color is the worst of those severities among asleep, duration, and WASO.</p>
   </div>
 
   <script src="dev-git-branch.js"></script>
@@ -102,122 +99,6 @@
       document.getElementById('about-remaining-wake-mount').innerHTML =
         getRemainingWakeThresholdsControlHTML('about-remaining-wake-thresholds');
       initRemainingWakeThresholdsConfig();
-    })();
-
-    (function() {
-      var deck = document.getElementById('about-deck');
-      var viewport = document.getElementById('about-slides-viewport');
-      var slidesEl = document.getElementById('about-slides');
-      var dotsEl = document.getElementById('about-dots');
-      var slides = slidesEl.querySelectorAll('.about-slide');
-      var total = slides.length;
-      var current = 0;
-      var touchStartX = 0;
-      var touchEndX = 0;
-      var minSwipe = 60;
-
-      var hashToIndex = { '': 0, 'remaining-wake-time': 1 };
-
-      function getSlideWidth() {
-        return viewport.offsetWidth || deck.offsetWidth || 400;
-      }
-
-      function setSlideWidths() {
-        var w = getSlideWidth();
-        for (var i = 0; i < slides.length; i++) slides[i].style.width = w + 'px';
-      }
-
-      function updateTransform() {
-        var px = current * getSlideWidth();
-        slidesEl.style.transform = 'translateX(-' + px + 'px)';
-      }
-
-      function updateDots() {
-        dotsEl.querySelectorAll('.about-dot').forEach(function(dot, i) {
-          dot.classList.toggle('active', i === current);
-          dot.setAttribute('aria-selected', i === current ? 'true' : 'false');
-        });
-      }
-
-      function goTo(index, skipHash) {
-        index = Math.max(0, Math.min(index, total - 1));
-        if (index === current) return;
-        current = index;
-        updateTransform();
-        updateDots();
-        if (!skipHash) {
-          var hash = index === 0 ? '' : (slides[current].id || '');
-          var url = location.pathname + location.search + (hash ? ('#' + hash) : '');
-          history.replaceState(null, '', url);
-        }
-      }
-
-      function buildDots() {
-        dotsEl.innerHTML = '';
-        for (var i = 0; i < total; i++) {
-          var dot = document.createElement('button');
-          dot.type = 'button';
-          dot.className = 'about-dot' + (i === 0 ? ' active' : '');
-          dot.setAttribute('role', 'tab');
-          dot.setAttribute('aria-label', 'Section ' + (i + 1) + ' of ' + total);
-          dot.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
-          dot.addEventListener('click', function() { goTo(Number(this.getAttribute('data-index'))); });
-          dot.setAttribute('data-index', String(i));
-          dotsEl.appendChild(dot);
-        }
-      }
-
-      deck.addEventListener('touchstart', function(e) {
-        touchStartX = e.changedTouches ? e.changedTouches[0].screenX : e.screenX;
-      }, { passive: true });
-
-      deck.addEventListener('touchend', function(e) {
-        touchEndX = e.changedTouches ? e.changedTouches[0].screenX : e.screenX;
-        var diff = touchStartX - touchEndX;
-        if (Math.abs(diff) >= minSwipe) {
-          if (diff > 0) goTo(current + 1);
-          else goTo(current - 1);
-        }
-      }, { passive: true });
-
-      deck.addEventListener('mousedown', function(e) {
-        touchStartX = e.screenX;
-      });
-      deck.addEventListener('mouseup', function(e) {
-        touchEndX = e.screenX;
-        var diff = touchStartX - touchEndX;
-        if (Math.abs(diff) >= minSwipe) {
-          if (diff > 0) goTo(current + 1);
-          else goTo(current - 1);
-        }
-      });
-
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'ArrowLeft') goTo(current - 1);
-        if (e.key === 'ArrowRight') goTo(current + 1);
-      });
-
-      var initialHash = (location.hash || '').replace(/^#/, '');
-      var initialIndex = hashToIndex[initialHash];
-      if (initialIndex !== undefined) {
-        current = initialIndex;
-      }
-
-      setSlideWidths();
-      buildDots();
-      updateTransform();
-      updateDots();
-
-      window.addEventListener('hashchange', function() {
-        var hash = (location.hash || '').replace(/^#/, '');
-        var idx = hashToIndex[hash];
-        goTo(idx === undefined ? 0 : idx, true);
-      });
-
-      window.addEventListener('resize', function() {
-        setSlideWidths();
-        updateTransform();
-      });
     })();
   </script>
 </body>

--- a/config.html
+++ b/config.html
@@ -1,4 +1,4 @@
-next<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">

--- a/daily.js
+++ b/daily.js
@@ -799,11 +799,27 @@ function renderMonthBlock(month, large) {
   `;
 }
 
-// Shared header and legend for sleep quality calendar (used by dashboard and quality page)
-function renderCalendarHeatmapHeader() {
+/** @param {{ qualityPage?: boolean }} [options] */
+function renderCalendarHeatmapHeader(options) {
+  const qualityPage = Boolean(options && options.qualityPage);
+  const swatchLegend = qualityPage
+    ? `
+      <ul class="calendar-heatmap-swatch-legend" aria-label="Daily flag severity">
+        <li><span class="quality-swatch quality-swatch--rested" aria-hidden="true"></span> <span><strong>Rested</strong> — on your recent pattern; no flag.</span></li>
+        <li><span class="quality-swatch quality-swatch--slight" aria-hidden="true"></span> <span><strong>Slightly</strong> off pattern.</span></li>
+        <li><span class="quality-swatch quality-swatch--moderate" aria-hidden="true"></span> <span><strong>Moderately</strong> off pattern.</span></li>
+        <li><span class="quality-swatch quality-swatch--severe" aria-hidden="true"></span> <span><strong>Severely</strong> off pattern.</span></li>
+      </ul>`
+    : '';
+  const aboutLink = qualityPage
+    ? `<p class="calendar-heatmap-about"><a class="content-link" href="about.html#daily-flags">About daily flags</a></p>`
+    : '';
   return `
-    <div class="calendar-heatmap-header">
-      <h3 class="calendar-heatmap-title">Sleep Quality history</h3>
+    <div class="calendar-heatmap-header${qualityPage ? ' calendar-heatmap-header--quality-page' : ''}">
+      <div class="calendar-heatmap-header-titles">
+        <h3 class="calendar-heatmap-title">Sleep Quality history</h3>
+        ${aboutLink}
+      </div>
       <div class="calendar-heatmap-legend calendar-heatmap-legend--compact">
         <div class="legend-colors-row">
           <span class="legend-label">need data</span>
@@ -830,8 +846,9 @@ function renderCalendarHeatmapHeader() {
           <span class="legend-meaning-item">🌅 wake vs avg</span>
           <span class="legend-meaning-item">🧩 WASO</span>
         </div>
-        <span class="legend-explanation legend-explanation--inline">(cell color from worst of 😴 ⌛ 🧩; 🌅 icon only; see Quality page for bands)</span>
+        <span class="legend-explanation legend-explanation--inline">(cell color from worst of 😴 ⌛ 🧩; 🌅 icon only)</span>
       </div>
+      ${swatchLegend}
     </div>
   `;
 }
@@ -856,8 +873,8 @@ function renderCalendarHeatmapFullHistory(year, flagMap, latestDataDate) {
   const months = generateCalendarHeatmap(year, flagMap, latestDataDate);
 
   return `
-    <div class="calendar-heatmap-container">
-      ${renderCalendarHeatmapHeader()}
+    <div class="calendar-heatmap-container calendar-heatmap-container--quality-page">
+      ${renderCalendarHeatmapHeader({ qualityPage: true })}
       <div class="calendar-heatmap">
         <div class="calendar-month-grid">
           ${months.map((month) => renderMonthBlock(month, false)).join('')}
@@ -1083,8 +1100,22 @@ function renderQuickAddDrawer(recentAverages, recentDays, layout = 'drawer') {
                 ${advancedBlocks}
               </div>`;
 
+  const clearAllBtn =
+    '<button type="button" class="about-theme-option" id="quick-add-clear-all" data-i18n="log.clearAll">Clear all</button>';
+  const pageTopToolbar = layout === 'page' ? `<div class="quick-add-page-toolbar">${clearAllBtn}</div>` : '';
+  const actionsInner =
+    layout === 'page'
+      ? `
+                <button type="button" class="about-theme-option" id="quick-add-cancel" data-i18n="log.cancel">Cancel</button>
+                <button type="submit" class="about-theme-option" id="quick-add-save" data-i18n="log.save">Save</button>`
+      : `
+                ${clearAllBtn}
+                <button type="button" class="about-theme-option" id="quick-add-cancel" data-i18n="log.cancel">Cancel</button>
+                <button type="submit" class="about-theme-option" id="quick-add-save" data-i18n="log.save">Save</button>`;
+
   const formHtml = `
             <form id="quick-add-form" class="quick-add-form" data-initial-bed="${bedVal}" data-initial-sleep="${sleepVal}" data-initial-wake="${wakeVal}">
+              ${pageTopToolbar}
               <div class="quick-add-field-compact quick-add-log-pair">
                 <label class="quick-add-label" for="quick-add-date"><span data-i18n="log.date">Date</span></label>
                 <input class="quick-add-input quick-add-input--date" id="quick-add-date" type="date">
@@ -1115,9 +1146,7 @@ function renderQuickAddDrawer(recentAverages, recentDays, layout = 'drawer') {
               ${advancedSection}
               <p class="quick-add-status" id="quick-add-status"></p>
               <div class="quick-add-actions">
-                <button type="button" class="about-theme-option" id="quick-add-clear-all" data-i18n="log.clearAll">Clear all</button>
-                <button type="button" class="about-theme-option" id="quick-add-cancel" data-i18n="log.cancel">Cancel</button>
-                <button type="submit" class="about-theme-option" id="quick-add-save" data-i18n="log.save">Save</button>
+                ${actionsInner}
               </div>
             </form>`;
 

--- a/entry-modal.js
+++ b/entry-modal.js
@@ -180,7 +180,7 @@
     if (napS) napS.value = '';
     if (napE) napE.value = '';
     const waso = document.getElementById('quick-add-waso');
-    if (waso) waso.value = '0';
+    if (waso) waso.value = '';
     setQuickAddStatus('', false);
   }
 
@@ -240,7 +240,7 @@
     const napStart = napStartRaw ? timeInputValueToNormalized(napStartRaw) : null;
     const napEnd = napEndRaw ? timeInputValueToNormalized(napEndRaw) : null;
     const wasoRaw = document.getElementById('quick-add-waso').value;
-    const waso = wasoRaw === '' ? 0 : Number(wasoRaw);
+    const wasoTrim = (wasoRaw != null ? String(wasoRaw) : '').trim();
 
     if (!dateMd || !bed || !sleepStart || !sleepEnd) {
       setQuickAddStatus('Pick a date and set bed, sleep, and wake times.', true);
@@ -254,46 +254,75 @@
       setQuickAddStatus('Nap times must be valid (use the time picker or adjust with − / +).', true);
       return;
     }
-    if (!Number.isFinite(waso) || waso < 0) {
-      setQuickAddStatus('WASO must be 0 or greater.', true);
-      return;
+    if (wasoTrim !== '') {
+      const wasoNum = Number(wasoTrim);
+      if (!Number.isFinite(wasoNum) || wasoNum < 0 || Math.floor(wasoNum) !== wasoNum) {
+        setQuickAddStatus('WASO must be a whole number 0 or greater.', true);
+        return;
+      }
     }
 
-    const saveBtn = document.getElementById('quick-add-save');
-    if (saveBtn) saveBtn.disabled = true;
-    setQuickAddStatus('Saving...', false);
-
-    const day = {
+    const baseDay = {
       date: dateMd,
       bed: bed,
       sleepStart: sleepStart,
       sleepEnd: sleepEnd,
       bathroom: bathroom,
       alarm: alarm,
-      nap: napStart && napEnd ? { start: napStart, end: napEnd } : null,
-      WASO: Math.floor(waso)
+      nap: napStart && napEnd ? { start: napStart, end: napEnd } : null
     };
 
-    upsertSleepDay(day)
-      .then(function () {
-        setQuickAddStatus('Saved.', false);
-        const drawerEl = document.getElementById('quick-add-drawer');
-        const isLogPage = drawerEl && drawerEl.classList.contains('quick-add-drawer--page');
-        if (!isLogPage) {
-          closeQuickAddDrawer();
-        }
-        if (quickAddOptions && typeof quickAddOptions.onSaved === 'function') {
-          return quickAddOptions.onSaved();
-        }
-        return null;
-      })
-      .catch(function (error) {
-        console.error(error);
-        setQuickAddStatus(error && error.message ? error.message : 'Could not save. Check Settings and try again.', true);
-      })
-      .finally(function () {
-        if (saveBtn) saveBtn.disabled = false;
-      });
+    function commitDayWithWaso(wasoInt) {
+      const saveBtn = document.getElementById('quick-add-save');
+      if (saveBtn) saveBtn.disabled = true;
+      setQuickAddStatus('Saving...', false);
+      const day = Object.assign({}, baseDay, { WASO: Math.floor(wasoInt) });
+      upsertSleepDay(day)
+        .then(function () {
+          setQuickAddStatus('Saved.', false);
+          const drawerEl = document.getElementById('quick-add-drawer');
+          const isLogPage = drawerEl && drawerEl.classList.contains('quick-add-drawer--page');
+          if (!isLogPage) {
+            closeQuickAddDrawer();
+          }
+          if (quickAddOptions && typeof quickAddOptions.onSaved === 'function') {
+            return quickAddOptions.onSaved();
+          }
+          return null;
+        })
+        .catch(function (error) {
+          console.error(error);
+          setQuickAddStatus(error && error.message ? error.message : 'Could not save. Check Settings and try again.', true);
+        })
+        .finally(function () {
+          if (saveBtn) saveBtn.disabled = false;
+        });
+    }
+
+    if (wasoTrim !== '') {
+      commitDayWithWaso(Number(wasoTrim));
+    } else {
+      const saveBtnPre = document.getElementById('quick-add-save');
+      if (saveBtnPre) saveBtnPre.disabled = true;
+      setQuickAddStatus('Saving...', false);
+      loadSleepData()
+        .then(function (data) {
+          const days = Array.isArray(data && data.days) ? data.days : [];
+          var preserved = 0;
+          for (var i = 0; i < days.length; i++) {
+            if (days[i].date === dateMd && Number.isFinite(days[i].WASO)) {
+              preserved = days[i].WASO;
+              break;
+            }
+          }
+          commitDayWithWaso(preserved);
+        })
+        .catch(function (err) {
+          console.error(err);
+          setQuickAddStatus('Could not load data to preserve WASO. Enter a number or try again.', true);
+          if (saveBtnPre) saveBtnPre.disabled = false;
+        });
+    }
   }
 
   function bindQuickAddHostOnce() {

--- a/quality.html
+++ b/quality.html
@@ -11,17 +11,6 @@
 <body class="quality-page">
   <div id="nav-container"></div>
   <div class="container">
-    <section class="quality-variation-guide" aria-labelledby="quality-variation-heading">
-      <h2 id="quality-variation-heading">How strong is a daily flag?</h2>
-      <p> The flag color is how far that measure drifted from your <strong>previous seven logged nights</strong>. (Fewer than 7 prior nights in the log will show an insufficient-data message.)</p>
-      <ul>
-        <li><span class="quality-swatch quality-swatch--rested" aria-hidden="true"></span> <span><strong>Rested</strong> — on your recent pattern; no flag.</span></li>
-        <li><span class="quality-swatch quality-swatch--slight" aria-hidden="true"></span> <span><strong>Slightly</strong> off pattern.</span></li>
-        <li><span class="quality-swatch quality-swatch--moderate" aria-hidden="true"></span> <span><strong>Moderately</strong> off pattern.</span></li>
-        <li><span class="quality-swatch quality-swatch--severe" aria-hidden="true"></span> <span><strong>Severely</strong> off pattern.</span></li>
-      </ul>
-      <strong>😴 Asleep</strong> is only flagged when you fell asleep <em>later</em> than your baseline; falling asleep earlier is not flagged. <strong>⌛ Duration</strong> uses the <em>worse</em> of two checks (not added together): shorter than your recent average, <em>or</em> absolute short sleep—under 6 hours (slight), under 5 hours (moderate), under 4 hours (severe)—based on total sleep including naps. <strong>🌅 Wake</strong> compares earlier or later than the baseline. <strong>🧩 WASO</strong> (wake after sleep onset) counts wake episodes longer than 20 minutes: 1 → slight, 2 → moderate, 3 or more → severe. On the <strong>history calendar</strong>, the cell color is the worst of those severities among asleep, duration, and WASO.</p>
-    </section>
     <div id="quality-container"></div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -3079,6 +3079,28 @@ svg {
   gap: 8px;
 }
 
+.calendar-heatmap-header--quality-page {
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-3);
+}
+
+.calendar-heatmap-header-titles {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.calendar-heatmap-header--quality-page .calendar-heatmap-title {
+  margin: 0;
+}
+
+.calendar-heatmap-about {
+  margin: 0;
+  font-size: 0.9375rem;
+}
+
 /* Dashboard: legend under the title */
 .calendar-heatmap-container--dashboard .calendar-heatmap-header {
   flex-direction: column;
@@ -3345,6 +3367,24 @@ svg {
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
+.quality-page .calendar-month-block {
+  background: #ffffff;
+  color: #0f172a;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="day"] .quality-page .calendar-month-block {
+  background: #ffffff;
+  border: 1px solid var(--grid);
+}
+
+.quality-page .calendar-month-block .calendar-month-name,
+.quality-page .calendar-month-block .calendar-month-flag-counter,
+.quality-page .calendar-month-block .calendar-flag-slot,
+.quality-page .calendar-month-block .calendar-weekday-label {
+  color: #0f172a;
+}
+
 .calendar-month-header {
   display: flex;
   flex-direction: column;
@@ -3473,33 +3513,23 @@ svg {
   z-index: 10;
 }
 
-/* Sleep Quality page — how daily severity maps to color */
-.quality-page .quality-variation-guide {
-  max-width: 42rem;
-  margin-bottom: var(--space-5);
-  padding: var(--panel-padding);
-  background: var(--panel);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--panel-border-color);
-  box-shadow: var(--panel-shadow);
-}
-
-.quality-page .quality-variation-guide h2 {
-  margin-top: 0;
-  font-size: 1.25rem;
-}
-
-.quality-page .quality-variation-guide ul {
+/* Sleep Quality page — severity swatches live under Sleep Quality history header */
+.quality-page .calendar-heatmap-swatch-legend {
   list-style: none;
-  padding-left: 0;
-  margin: 0.75rem 0 0;
+  padding: 0;
+  margin: 0;
+  max-width: 42rem;
 }
 
-.quality-page .quality-variation-guide li {
+.quality-page .calendar-heatmap-swatch-legend li {
   display: flex;
   align-items: baseline;
   gap: 10px;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.quality-page .calendar-heatmap-swatch-legend li:last-child {
+  margin-bottom: 0;
 }
 
 .quality-swatch {
@@ -3973,59 +4003,6 @@ svg {
   white-space: nowrap;
 }
 
-/* About page — section slider (swipeable deck) */
-.about-deck {
-  display: flex;
-  flex-direction: column;
-  margin: 0 -20px;
-  padding: 0;
-}
-.about-slides-viewport {
-  width: 100%;
-  overflow: hidden;
-}
-.about-slides {
-  display: flex;
-  flex-wrap: nowrap;
-  transition: transform 0.35s ease-out;
-  will-change: transform;
-}
-.about-slide {
-  flex: 0 0 auto;
-  min-width: 0;
-}
-.about-slide-inner {
-  margin: 0 20px 24px;
-}
-.about-slide-inner .section-title:first-child {
-  margin-top: 0;
-}
-.about-dots {
-  display: flex;
-  justify-content: center;
-  gap: 10px;
-  padding: 16px 0 8px;
-}
-.about-dots .about-dot {
-  pointer-events: auto;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: none;
-  padding: 0;
-  background: var(--text);
-  opacity: 0.35;
-  cursor: pointer;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-.about-dots .about-dot:hover {
-  opacity: 0.6;
-}
-.about-dots .about-dot.active {
-  opacity: 1;
-  transform: scale(1.2);
-}
-
 /* About page — getting started list */
 .about-intro {
   margin-bottom: 1rem;
@@ -4080,8 +4057,14 @@ svg {
   color: var(--text);
 }
 
-.about-slide-inner .about-rw-thresholds-heading {
+.about-rw-thresholds-heading {
   margin-top: 1.75rem;
+  margin-bottom: 0.4rem;
+  font-size: 1.1rem;
+}
+
+.about-daily-flags-subheading.section-title {
+  margin-top: 0.75rem;
   margin-bottom: 0.4rem;
   font-size: 1.1rem;
 }
@@ -4755,7 +4738,13 @@ button.dashboard-quick-action-btn {
   margin-top: var(--space-2);
 }
 
-#quick-add-clear-all {
+.quick-add-page-toolbar {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: var(--space-3);
+}
+
+.quick-add-actions #quick-add-clear-all {
   margin-right: auto;
 }
 


### PR DESCRIPTION
About (about.html + styles.css)
- Dropped the swipeable “deck” (slides, dots, swipe/keyboard JS) and made one scrollable page aligned with Settings (container--config, h1 “About”, h2 sections).
- Added Daily flags: text moved from Quality (split into separate paragraphs per flag / calendar rule).
- Removed deck-only CSS; kept shared About styles; .about-rw-thresholds-heading no longer tied to slide wrappers.

Quality (quality.html, daily.js, styles.css)
- Removed the standalone intro quality-variation-guide block from HTML.
- Sleep Quality history header (from renderCalendarHeatmapFullHistory) now includes “About daily flags”, the heatmap legend, and the Rested → Severe swatch list.
- Month blocks on the quality page use white backgrounds and dark month chrome text so labels stay readable.

Log / entry form (daily.js, entry-modal.js, styles.css)
- Clear all on the Log page sits in a top toolbar; Cancel / Save stay at the bottom (drawer unchanged: Clear still in the bottom row with margin-right: auto).
- Clear all clears WASO to empty (not 0). On save, an empty WASO loads existing data for that date and reuses stored WASO; new nights still behave like 0 when there’s no prior row.