### PR TITLE
Add sleep tags

### DIFF
--- a/about.html
+++ b/about.html
@@ -86,6 +86,9 @@
     <p class="section-intro"><strong>🌅 Wake</strong> compares earlier or later than the baseline.</p>
     <p class="section-intro"><strong>🧩 WASO</strong> (wake after sleep onset) counts wake episodes longer than 20 minutes: 1 → slight, 2 → moderate, 3 or more → severe.</p>
     <p class="section-intro">On the <strong>history calendar</strong>, the cell color is the worst of those severities among asleep, duration, and WASO.</p>
+
+    <h2 class="section-title" id="night-labels">Night notes (emoji labels)</h2>
+    <p class="section-intro">From the <strong>Log</strong> screen you can tag a night with optional emoji &ldquo;notes&rdquo; (kids, alcohol, travel, stress, work, caffeine, late meal, illness). They are saved with that night&rsquo;s row, show next to <a class="content-link" href="#daily-flags">daily flags</a> on the timeline and dashboard, and do not change scores or charts.</p>
   </div>
 
   <script src="dev-git-branch.js"></script>

--- a/daily.js
+++ b/daily.js
@@ -344,6 +344,31 @@ function escapeHtmlText(s) {
     .replace(/>/g, '&gt;');
 }
 
+function sleepDayUserLabelsMarkup(day) {
+  const normalized =
+    typeof normalizeSleepDayLabels === 'function'
+      ? normalizeSleepDayLabels(day && day.labels)
+      : Array.isArray(day && day.labels)
+        ? day.labels
+        : [];
+  if (!normalized.length) return '';
+  const defs = typeof SLEEP_DAY_LABEL_OPTIONS !== 'undefined' ? SLEEP_DAY_LABEL_OPTIONS : [];
+  function titleFor(emoji) {
+    for (let i = 0; i < defs.length; i++) {
+      if (defs[i].emoji === emoji) return defs[i].title;
+    }
+    return '';
+  }
+  const chips = normalized
+    .map(function (emoji) {
+      const tit = titleFor(emoji);
+      const aria = escapeHtmlAttr(tit || emoji);
+      return `<span class="sleep-day-user-label" role="img" aria-label="${aria}" title="${aria}">${emoji}</span>`;
+    })
+    .join('');
+  return `<div class="sleep-day-user-labels" aria-label="Night notes">${chips}</div>`;
+}
+
 function deviationWarningMarkup(w) {
   if (typeof w === 'string') {
     return `<button type="button" class="deviation-flag-chip deviation-flag-chip--insufficient" aria-expanded="false" aria-label="${escapeHtmlAttr(w)}"><span class="deviation-flag-chip-icon" aria-hidden="true">⋯</span><span class="deviation-flag-chip-text">${escapeHtmlText(w)}</span></button>`;
@@ -443,6 +468,11 @@ function renderDay(day, days, dayIndex, options) {
   const deviationWarnings = deviations.length > 0
     ? `<div class="deviation-warnings deviation-warnings--chips">${deviations.map(deviationWarningMarkup).join('')}</div>`
     : '';
+  const userLabelsBlock = sleepDayUserLabelsMarkup(day);
+  const dayFlagsRow =
+    deviationWarnings || userLabelsBlock
+      ? `<div class="day-flags-row">${deviationWarnings}${userLabelsBlock}</div>`
+      : '';
   
   // Convert times to timeline positions
   const sleepStartPos = timeToTimelinePosition(sleepStart);
@@ -503,7 +533,7 @@ function renderDay(day, days, dayIndex, options) {
   
   html += `</div></div>
       </div>
-      ${deviationWarnings}
+      ${dayFlagsRow}
     </div>`;
   return html;
 }
@@ -1100,6 +1130,10 @@ function renderQuickAddDrawer(recentAverages, recentDays, layout = 'drawer') {
                       </div>
                     </div>
                   </div>
+                  <div class="quick-add-adv-row quick-add-labels-row quick-add-log-pair">
+                    <span class="quick-add-label quick-add-label--emoji-line" id="quick-add-labels-legend"><span class="quick-add-log-emoji" aria-hidden="true">🏷️</span><span class="quick-add-label-text" data-i18n="log.nightLabels">Night notes</span></span>
+                    <div class="quick-add-label-chips" id="quick-add-label-chips" role="group" aria-labelledby="quick-add-labels-legend" data-i18n-aria-label="log.nightLabelsAria" aria-label="Optional emoji labels for this night"></div>
+                  </div>
                 </div>`;
   const advancedSection =
     layout === 'drawer'
@@ -1583,8 +1617,8 @@ function toggleDailyDetails(show) {
 
 // Toggle deviation warnings/flags visibility
 function toggleFlags(show) {
-  document.querySelectorAll('.deviation-warnings').forEach(warnings => {
-    warnings.classList.toggle('hidden', !show);
+  document.querySelectorAll('.day-flags-row').forEach(row => {
+    row.classList.toggle('hidden', !show);
   });
 }
 

--- a/entry-modal.js
+++ b/entry-modal.js
@@ -176,6 +176,7 @@
     if (napE) napE.value = '';
     const waso = document.getElementById('quick-add-waso');
     if (waso) waso.value = '0';
+    syncQuickAddLabelToggles([]);
     setQuickAddStatus('', false);
   }
 
@@ -195,12 +196,75 @@
     if (napE) napE.value = '';
     const waso = document.getElementById('quick-add-waso');
     if (waso) waso.value = '';
+    syncQuickAddLabelToggles([]);
     setQuickAddStatus('', false);
   }
 
   function closeQuickAddDrawer() {
     setDrawerExpanded(false);
     resetQuickAddFormToDefaults();
+  }
+
+  function escapeLabelAttr(s) {
+    return String(s || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;');
+  }
+
+  function ensureQuickAddLabelChipsRendered() {
+    const host = document.getElementById('quick-add-label-chips');
+    if (!host || typeof SLEEP_DAY_LABEL_OPTIONS === 'undefined') return;
+    if (host.getAttribute('data-chips-rendered') === '1') return;
+    host.setAttribute('data-chips-rendered', '1');
+    host.innerHTML = SLEEP_DAY_LABEL_OPTIONS.map(function (opt) {
+      const tit = escapeLabelAttr(opt.title);
+      return (
+        '<button type="button" class="sleep-day-label-toggle" data-emoji="' +
+        opt.emoji +
+        '" aria-pressed="false" aria-label="' +
+        tit +
+        '" title="' +
+        tit +
+        '"><span class="sleep-day-label-toggle__emoji" aria-hidden="true">' +
+        opt.emoji +
+        '</span></button>'
+      );
+    }).join('');
+  }
+
+  function syncQuickAddLabelToggles(labels) {
+    const host = document.getElementById('quick-add-label-chips');
+    if (!host) return;
+    const set = {};
+    for (let i = 0; i < labels.length; i++) set[labels[i]] = true;
+    const btns = host.querySelectorAll('.sleep-day-label-toggle');
+    for (let j = 0; j < btns.length; j++) {
+      const btn = btns[j];
+      const e = btn.getAttribute('data-emoji');
+      const on = Boolean(e && set[e]);
+      btn.classList.toggle('is-pressed', on);
+      btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+    }
+  }
+
+  function labelsFromRecord(record) {
+    if (typeof normalizeSleepDayLabels === 'function') {
+      return normalizeSleepDayLabels(record && record.labels);
+    }
+    return Array.isArray(record && record.labels) ? record.labels : [];
+  }
+
+  function collectQuickAddLabelsFromDom() {
+    const host = document.getElementById('quick-add-label-chips');
+    if (!host) return [];
+    const out = [];
+    const pressed = host.querySelectorAll('.sleep-day-label-toggle.is-pressed');
+    for (let i = 0; i < pressed.length; i++) {
+      const e = pressed[i].getAttribute('data-emoji');
+      if (e) out.push(e);
+    }
+    return typeof normalizeSleepDayLabels === 'function' ? normalizeSleepDayLabels(out) : out;
   }
 
   function wireQuickAddDrawerSliders() {
@@ -210,6 +274,7 @@
     const dateInput = document.getElementById('quick-add-date');
     if (dateInput) dateInput.value = quickAddPresetDateInputValue();
     initQuickAddDynamicTimeLists();
+    ensureQuickAddLabelChipsRendered();
 
     const waso = document.getElementById('quick-add-waso');
     if (waso && (waso.value === '' || waso.value === null)) waso.value = '0';
@@ -262,6 +327,8 @@
       if (napS) napS.value = '';
       if (napE) napE.value = '';
       if (waso) waso.value = '0';
+      ensureQuickAddLabelChipsRendered();
+      syncQuickAddLabelToggles([]);
       return;
     }
 
@@ -273,6 +340,8 @@
     if (napS) napS.value = toTimeInputValue(record.nap && record.nap.start);
     if (napE) napE.value = toTimeInputValue(record.nap && record.nap.end);
     if (waso) waso.value = String(Number.isFinite(record.WASO) ? Math.max(0, Math.floor(record.WASO)) : 0);
+    ensureQuickAddLabelChipsRendered();
+    syncQuickAddLabelToggles(labelsFromRecord(record));
   }
 
   function loadQuickAddFormForDate(dateMd) {
@@ -355,9 +424,22 @@
     if (napStart && napEnd) partial.nap = { start: napStart, end: napEnd };
     if (wasoTrim !== '') partial.WASO = Math.floor(Number(wasoTrim));
 
-    if (Object.keys(partial).length === 0) {
+    const labelsSelected = collectQuickAddLabelsFromDom();
+    partial.labels = labelsSelected;
+
+    const hasOther =
+      Boolean(bed) ||
+      Boolean(sleepStart) ||
+      Boolean(sleepEnd) ||
+      bathroom.length > 0 ||
+      alarm.length > 0 ||
+      Boolean(napStart && napEnd) ||
+      wasoTrim !== '';
+    if (!hasOther && labelsSelected.length === 0) {
       setQuickAddStatus(
-        typeof t === 'function' ? t('log.errorNeedField', 'Pick a date and fill at least one field to save.') : 'Pick a date and fill at least one field to save.',
+        typeof t === 'function'
+          ? t('log.errorNeedField', 'Pick a date and add at least one field or night note to save.')
+          : 'Pick a date and add at least one field or night note to save.',
         true
       );
       return;
@@ -434,6 +516,14 @@
       if (rm && form.contains(rm)) {
         e.preventDefault();
         onQuickAddRemoveTimeRow(rm);
+        return;
+      }
+
+      const labelBtn = t.closest && t.closest('.sleep-day-label-toggle');
+      if (labelBtn && form.contains(labelBtn)) {
+        e.preventDefault();
+        const nowOn = labelBtn.classList.toggle('is-pressed');
+        labelBtn.setAttribute('aria-pressed', nowOn ? 'true' : 'false');
         return;
       }
 

--- a/locales.json
+++ b/locales.json
@@ -102,7 +102,9 @@
       "napEndLaterAria": "Nap end one minute later",
       "napEndEarlierAria": "Nap end one minute earlier",
       "errorPickDate": "Pick a valid date.",
-      "errorNeedField": "Pick a date and fill at least one field to save."
+      "errorNeedField": "Pick a date and add at least one field or night note to save.",
+      "nightLabels": "Night notes",
+      "nightLabelsAria": "Optional emoji labels for this night"
     }
   },
   "ja": {
@@ -208,7 +210,9 @@
       "napEndLaterAria": "仮眠の終了を1分遅く",
       "napEndEarlierAria": "仮眠の終了を1分早く",
       "errorPickDate": "有効な日付を選んでください。",
-      "errorNeedField": "日付を選び、保存する項目を1つ以上入力してください。"
+      "errorNeedField": "日付を選び、項目または夜のメモ（絵文字）を1つ以上指定して保存してください。",
+      "nightLabels": "夜のメモ",
+      "nightLabelsAria": "この夜の任意の絵文字ラベル"
     }
   }
 }

--- a/math-tests.js
+++ b/math-tests.js
@@ -57,6 +57,12 @@ function runTests() {
   expectEqual(u.modMinutes1440(-1), 1439, 'modMinutes1440 negative input');
   expectEqual(u.modMinutes1440(1445), 5, 'modMinutes1440 overflow input');
 
+  expectEqual(
+    JSON.stringify(u.normalizeSleepDayLabels(['🍺', '👶', 'nope'])),
+    JSON.stringify(['👶', '🍺']),
+    'normalizeSleepDayLabels filters and orders'
+  );
+
   // Sleep totals + nap handling
   const napCrossingMidnightDay = {
     sleepStart: '23:30',

--- a/sleep-utils.js
+++ b/sleep-utils.js
@@ -19,6 +19,31 @@ const HOLIDAYS_BY_YEAR = {
 };
 if (typeof window !== 'undefined') window.HOLIDAYS_BY_YEAR = HOLIDAYS_BY_YEAR;
 
+/** Fixed emoji keys for optional per-night labels (log + daily display). Order is canonical storage order. */
+const SLEEP_DAY_LABEL_OPTIONS = [
+  { emoji: '👶', title: 'Kids' },
+  { emoji: '🍺', title: 'Alcohol' },
+  { emoji: '✈️', title: 'Travel' },
+  { emoji: '😰', title: 'Stress' },
+  { emoji: '💼', title: 'Work' },
+  { emoji: '☕', title: 'Caffeine' },
+  { emoji: '🍝', title: 'Late meal / heavy dinner' },
+  { emoji: '🤒', title: 'Illness' }
+];
+if (typeof window !== 'undefined') window.SLEEP_DAY_LABEL_OPTIONS = SLEEP_DAY_LABEL_OPTIONS;
+
+const SLEEP_DAY_LABEL_EMOJI_SET = new Set(SLEEP_DAY_LABEL_OPTIONS.map(function (o) { return o.emoji; }));
+
+function normalizeSleepDayLabels(value) {
+  const raw = Array.isArray(value) ? value : [];
+  const picked = new Set();
+  for (let i = 0; i < raw.length; i++) {
+    const e = raw[i];
+    if (e != null && SLEEP_DAY_LABEL_EMOJI_SET.has(String(e))) picked.add(String(e));
+  }
+  return SLEEP_DAY_LABEL_OPTIONS.map(function (o) { return o.emoji; }).filter(function (e) { return picked.has(e); });
+}
+
 const SUPABASE_URL_STORAGE_KEY = 'restore_supabase_url';
 const SUPABASE_ANON_KEY_STORAGE_KEY = 'restore_supabase_anon_key';
 const RESTORE_LAST_DATA_SOURCE_KEY = 'restore_last_data_source';
@@ -288,7 +313,8 @@ function mapSupabaseRowToDay(row) {
     nap: row.nap_start
       ? { start: row.nap_start, end: row.nap_end != null && row.nap_end !== '' ? row.nap_end : null }
       : null,
-    WASO: Number.isFinite(row.waso) ? row.waso : 0
+    WASO: Number.isFinite(row.waso) ? row.waso : 0,
+    labels: normalizeSleepDayLabels(row.labels)
   };
 }
 
@@ -347,7 +373,8 @@ function emptySleepDayForDate(dateMd) {
     bathroom: [],
     alarm: [],
     nap: null,
-    WASO: 0
+    WASO: 0,
+    labels: []
   };
 }
 
@@ -358,7 +385,7 @@ function emptySleepDayForDate(dateMd) {
 function mergePartialSleepDayForUpsert(existing, dateMd, partial) {
   const base = existing ? JSON.parse(JSON.stringify(existing)) : emptySleepDayForDate(dateMd);
   base.date = dateMd;
-  const fields = ['bed', 'sleepStart', 'sleepEnd', 'bathroom', 'alarm', 'nap', 'WASO'];
+  const fields = ['bed', 'sleepStart', 'sleepEnd', 'bathroom', 'alarm', 'nap', 'WASO', 'labels'];
   for (let i = 0; i < fields.length; i++) {
     const k = fields[i];
     if (k in partial) base[k] = partial[k];
@@ -378,7 +405,8 @@ function mapDayToSupabaseRow(day) {
     alarm: alarm,
     nap_start: day.nap && day.nap.start != null && day.nap.start !== '' ? normalizeTimeStringForSupabase(day.nap.start) : null,
     nap_end: day.nap && day.nap.end != null && day.nap.end !== '' ? normalizeTimeStringForSupabase(day.nap.end) : null,
-    waso: Number.isFinite(day.WASO) ? day.WASO : 0
+    waso: Number.isFinite(day.WASO) ? day.WASO : 0,
+    labels: normalizeSleepDayLabels(day.labels)
   };
 }
 
@@ -405,6 +433,9 @@ function mapPartialDayToDraftPatch(partial) {
   }
   if ('WASO' in partial) {
     patch.waso = Number.isFinite(partial.WASO) ? Math.max(0, Math.floor(partial.WASO)) : 0;
+  }
+  if ('labels' in partial) {
+    patch.labels = normalizeSleepDayLabels(partial.labels);
   }
   return patch;
 }
@@ -443,7 +474,7 @@ function fetchStaticSleepData() {
 }
 
 function fetchSupabaseSleepData(config) {
-  const url = config.url.replace(/\/+$/, '') + '/rest/v1/sleep_days?select=date_md,bed,sleep_start,sleep_end,bathroom,alarm,nap_start,nap_end,waso';
+  const url = config.url.replace(/\/+$/, '') + '/rest/v1/sleep_days?select=date_md,bed,sleep_start,sleep_end,bathroom,alarm,nap_start,nap_end,waso,labels';
   return fetch(url, {
     headers: {
       apikey: config.anonKey,
@@ -564,7 +595,7 @@ function getSleepDayByDate(dateMd) {
 function getSleepDraftByDate(dateMd) {
   const config = getSupabaseConfig();
   if (!config.enabled || !dateMd) return Promise.resolve(null);
-  const select = 'date_md,bed,sleep_start,sleep_end,bathroom,alarm,nap_start,nap_end,waso';
+  const select = 'date_md,bed,sleep_start,sleep_end,bathroom,alarm,nap_start,nap_end,waso,labels';
   const qDate = encodeURIComponent(dateMd);
   const url = config.url.replace(/\/+$/, '') + '/rest/v1/sleep_day_drafts?select=' + select + '&date_md=eq.' + qDate + '&limit=1';
   return fetch(url, {

--- a/styles.css
+++ b/styles.css
@@ -2213,6 +2213,96 @@ body{
   display: none;
 }
 
+.day-flags-row{
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.day-flags-row .deviation-warnings{
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.day-flags-row.hidden{
+  display: none;
+}
+
+.sleep-day-user-labels{
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.sleep-day-user-label{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  min-height: 1.75rem;
+  padding: 2px 4px;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-radius: 6px;
+  background: var(--surface-elevated, rgba(128, 128, 128, 0.12));
+  border: 1px solid var(--border-subtle, rgba(128, 128, 128, 0.25));
+}
+
+.quick-add-labels-row .quick-add-label-chips{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 2.5rem;
+}
+
+.sleep-day-label-toggle{
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  padding: 4px 6px;
+  font: inherit;
+  line-height: 1;
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle, rgba(128, 128, 128, 0.35));
+  background: var(--surface-elevated, rgba(128, 128, 128, 0.08));
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition: background 0.12s ease, box-shadow 0.12s ease, transform 0.08s ease;
+}
+
+.sleep-day-label-toggle:hover{
+  background: var(--surface-hover, rgba(128, 128, 128, 0.16));
+}
+
+.sleep-day-label-toggle:focus-visible{
+  outline: 2px solid var(--focus-ring, #3b82f6);
+  outline-offset: 2px;
+}
+
+.sleep-day-label-toggle.is-pressed{
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.22);
+  background: var(--surface-pressed, rgba(128, 128, 128, 0.22));
+  border-color: var(--border-strong, rgba(128, 128, 128, 0.45));
+}
+
+.sleep-day-label-toggle__emoji{
+  font-size: 1.25rem;
+  pointer-events: none;
+}
+
 .stat-row{
   display: flex;
   gap: 8px;

--- a/supabase/migrate-json-to-supabase.js
+++ b/supabase/migrate-json-to-supabase.js
@@ -21,7 +21,8 @@ function mapDayToRow(day) {
     alarm: Array.isArray(day.alarm) ? day.alarm : [],
     nap_start: day.nap && day.nap.start ? day.nap.start : null,
     nap_end: day.nap && day.nap.end ? day.nap.end : null,
-    waso: Number.isFinite(day.WASO) ? day.WASO : 0
+    waso: Number.isFinite(day.WASO) ? day.WASO : 0,
+    labels: Array.isArray(day.labels) ? day.labels : []
   };
 }
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -10,6 +10,7 @@ create table if not exists public.sleep_days (
   nap_start text,
   nap_end text,
   waso integer not null default 0 check (waso >= 0),
+  labels text[] not null default '{}',
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
@@ -25,6 +26,7 @@ create table if not exists public.sleep_day_drafts (
   nap_start text,
   nap_end text,
   waso integer not null default 0 check (waso >= 0),
+  labels text[] not null default '{}',
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
@@ -100,6 +102,13 @@ begin
     waso = case
       when v_patch ? 'waso' then greatest(0, coalesce((v_patch->>'waso')::integer, 0))
       else waso
+    end,
+    labels = case
+      when v_patch ? 'labels' then coalesce(
+        (select array_agg(value) from jsonb_array_elements_text(v_patch->'labels') as value),
+        '{}'::text[]
+      )
+      else labels
     end
   where d.date_md = p_date_md
   returning * into v_draft;
@@ -119,7 +128,8 @@ begin
       alarm,
       nap_start,
       nap_end,
-      waso
+      waso,
+      labels
     )
     values (
       v_draft.date_md,
@@ -130,7 +140,8 @@ begin
       coalesce(v_draft.alarm, '{}'::text[]),
       v_draft.nap_start,
       v_draft.nap_end,
-      coalesce(v_draft.waso, 0)
+      coalesce(v_draft.waso, 0),
+      coalesce(v_draft.labels, '{}'::text[])
     )
     on conflict on constraint sleep_days_date_md_key do update set
       bed = excluded.bed,
@@ -140,7 +151,8 @@ begin
       alarm = excluded.alarm,
       nap_start = excluded.nap_start,
       nap_end = excluded.nap_end,
-      waso = excluded.waso;
+      waso = excluded.waso,
+      labels = excluded.labels;
 
     delete from public.sleep_day_drafts where sleep_day_drafts.date_md = p_date_md;
   end if;


### PR DESCRIPTION
Add proto sleep tag system.

Lets user add more info about a night. Does not affect quality or averages.

May have future use case of "sort" or "filter," but current prototype version only handles adding.

Updated database (canon and draft) to handle tags (UTF-8 emojis)